### PR TITLE
🐞 收紧 clean 状态自动合并 fallback

### DIFF
--- a/.agents/skills/git-commit-helper/SKILL.md
+++ b/.agents/skills/git-commit-helper/SKILL.md
@@ -19,8 +19,8 @@ All repository delivery goes through a feature branch, a permanent change record
 6. After implementation and focused tests, update the record to `implemented`. After fresh full verification, update it to `verified` and record exact commands/results.
 7. Commit with `emoji type(scope): 简体中文描述`. Every body must contain non-empty `功能修改`, `影响范围`, and `验证结果` headings. Never add AI attribution or `Co-authored-by`.
 8. Rebase on current `origin/main`, rerun full verification, and push only the feature branch.
-9. Create or update the PR with the record summary, risks, and verification. Enable `auto-merge`; do not request human approval. Monitor `policy`, `tests-windows`, and `tests-macos`, fixing failures instead of bypassing them.
-10. Never create or push tags manually. The main-branch release coordinator selects SemVer from verified change records and dispatches both release workflows.
+9. Create or update the PR with the record summary, risks, and verification. Attempt to enable `auto-merge`; do not request human approval. The required checks `policy`, `tests-windows`, and `tests-macos` must all succeed before merging. If enabling auto-merge fails, only an explicit GitHub error stating that the PR is already `clean` permits a fallback. Before that fallback, re-query the PR 的准确 head SHA (exact PR head SHA) and independently verify all three checks are successful for that SHA. Only then may the Agent squash merge that exact head SHA and verify the resulting merge commit. 其他错误、缺少检查、检查非成功状态或 SHA 变化都是 hard stop; never merge by branch name, stale SHA, ambiguous ref, or an unverified state.
+10. Never create or push tags manually. The main-branch release coordinator selects SemVer from verified change records and dispatches both release workflows. Report the PR URL, check URLs and states, auto-merge or `clean` fallback result, release workflow URL, and both platform workflow results.
 
 ## Commit Types
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,15 +31,18 @@ python scripts/team_policy.py install-hooks
 - 每次提交前必须检查完整 staged/unstaged diff，并按独立关注点拆分。
 - commit 标题必须为前置 emoji 的 Conventional Commit 中文描述；正文必须包含非空的 `功能修改`、`影响范围`、`验证结果`。
 - 禁止直接推送 `main` 和任何标签。功能分支必须 rebase 到最新 `origin/main` 并针对准确 HEAD 重新完整验证。
-- Agent 必须创建或更新 PR、填写功能说明和验证证据，并启用 auto-merge。
-- PR 不要求人工审批；`policy`、`tests-windows`、`tests-macos` 三个 required checks 全部通过后才允许自动合并。失败必须修复，禁止绕过。
+- Agent 必须创建或更新 PR、填写功能说明和验证证据，并尝试启用 auto-merge。
+- PR 不要求人工审批；`policy`、`tests-windows`、`tests-macos` 三个 required checks 全部成功后才允许自动合并。
+- 如果启用 auto-merge 失败，只有 GitHub 明确报告 PR 已处于 `clean` 状态时允许进入 fallback；任何其他错误都必须停止并报告，禁止直接合并、重试绕过或猜测状态。
+- 进入 `clean` fallback 前，Agent 必须重新查询 PR 的准确 head SHA，并逐项确认 `policy`、`tests-windows`、`tests-macos` 当前针对该 SHA 全部成功；缺少任一检查、检查不是成功状态或 head SHA 发生变化，都必须停止。
+- 仅在上述条件全部满足后，才允许使用该准确 head SHA 执行 squash merge，并在合并后验证目标提交；禁止使用分支名、旧 SHA、模糊 ref 或无 SHA 合并。
 
 ## 自动版本与自动发版
 
 - Agent 在功能说明中根据兼容性选择 `major`、`minor`、`patch` 或 `none`，并在说明中给出理由，不等待人工决定版本号。
 - PR 合并后由 `auto-release` 工作流读取自上个标签以来新增且 `verified` 的说明，选择最高 bump、生成 release notes、创建唯一标签，并显式触发 Windows 与 macOS 发布工作流。
 - 正常流程禁止 Agent 手工创建或推送标签。只有自动发布工作流可以执行标签操作。
-- Agent 必须跟踪 PR checks、auto-merge、自动发布和两个平台发布结果，报告 URL、状态和具体失败步骤。
+- Agent 必须跟踪 PR checks、auto-merge 或 `clean` fallback、自动发布和两个平台发布结果，报告 URL、状态和具体失败步骤。
 
 ## 硬停止条件
 

--- a/docs/changes/2026-08-07-auto-merge-clean-fallback.md
+++ b/docs/changes/2026-08-07-auto-merge-clean-fallback.md
@@ -1,0 +1,59 @@
++++
+id = "2026-08-07-auto-merge-clean-fallback"
+type = "fix"
+release_bump = "none"
+status = "verified"
++++
+
+# 收紧 clean 状态自动合并 fallback
+
+## 目标
+
+明确 GitHub 在 required checks 全部通过后拒绝启用 auto-merge 时的唯一安全处理方式，避免 Agent 将任意 API 错误误判为可直接合并。
+
+## 现状
+
+交付约束要求 Agent 启用 auto-merge，但 GitHub 在 PR 已处于 `clean` 状态时可能返回 `Pull request is in clean status`。现有文档没有规定该特殊状态的可验证 fallback，也没有明确禁止其他错误触发直接合并。
+
+## 设计范围
+
+- 仅允许在 auto-merge 启用失败原因为 `clean` 时进入 fallback。
+- fallback 前必须查询 PR 的准确 head SHA，并确认 `policy`、`tests-windows`、`tests-macos` 三个 required checks 全部成功。
+- fallback 必须使用该准确 head SHA 执行 squash merge，并在合并后验证目标提交。
+- 将上述约束同步到根目录 Agent 规则、仓库 commit helper 和治理测试。
+
+## 非目标
+
+不改变 GitHub Ruleset、required checks、PR 审批数量、版本选择或自动发版工作流；不实现新的 GitHub API 客户端。
+
+## 兼容性
+
+无运行时影响，仅收紧 Agent 交付文档和对应治理测试；`release_bump = "none"`，不产生产品版本发布。
+
+## 风险
+
+GitHub API 错误文本或检查状态查询不完整时，Agent 将硬停止并要求人工排查，可能延迟合并，但不会绕过 required checks。合并 API 权限不足或 head SHA 发生变化时必须停止，禁止使用模糊 ref 重试。
+
+## 测试计划
+
+- 增加治理测试，检查 AGENTS.md 和 git-commit-helper 明确 clean-only、准确 head SHA、三个 checks 全部成功、squash merge 和其他错误硬停止。
+- 运行 Python 全量单元测试、Node 语法检查和 Node 测试。
+- 在 rebase 后运行仓库 pre-push 完整验证，并在 PR 上确认三个 required checks。
+
+## 实际改动
+
+- `AGENTS.md` 将 auto-merge 失败的 `clean` fallback 限定为唯一可恢复路径，要求准确 head SHA、三个 required checks 全成功、squash merge 和合并后验证。
+- `.agents/skills/git-commit-helper/SKILL.md` 同步相同的硬停止条件，并要求记录 PR、checks、auto-merge/fallback 和发布结果。
+- `tests/test_team_policy.py` 增加治理测试，防止移除上述限制。
+
+## 验证结果
+
+- `python -m unittest tests.test_team_policy.RepositoryGovernanceAssetTests.test_clean_auto_merge_fallback_is_strictly_bounded`：通过，1 项。
+- `python -m unittest discover -s tests -p "test_*.py"`：通过，357 项。
+- `node --check proxy_static/app.js`：通过。
+- `node --check provider_status/static/app.js`：通过。
+- `Get-ChildItem tests -Filter *.test.js | ForEach-Object { node --test $_.FullName }`：通过，全部 JavaScript 测试通过。
+
+## PR
+
+pending

--- a/docs/changes/2026-08-07-auto-merge-clean-fallback.md
+++ b/docs/changes/2026-08-07-auto-merge-clean-fallback.md
@@ -56,4 +56,4 @@ GitHub API 错误文本或检查状态查询不完整时，Agent 将硬停止并
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/3

--- a/tests/test_team_policy.py
+++ b/tests/test_team_policy.py
@@ -197,6 +197,22 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
         self.assertIn("自动发版", agents)
         self.assertNotIn("只有用户针对具体版本号", agents)
 
+    def test_clean_auto_merge_fallback_is_strictly_bounded(self) -> None:
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        skill = (ROOT / ".agents/skills/git-commit-helper/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+
+        for content in (agents, skill):
+            self.assertIn("clean", content)
+            self.assertIn("准确 head SHA", content)
+            self.assertIn("policy", content)
+            self.assertIn("tests-windows", content)
+            self.assertIn("tests-macos", content)
+            self.assertIn("squash merge", content)
+            self.assertIn("其他错误", content)
+            self.assertIn("禁止", content)
+
     def test_hook_wrappers_are_versioned_and_call_policy(self) -> None:
         for hook_name in ("pre-commit", "commit-msg", "pre-push"):
             content = (ROOT / ".githooks" / hook_name).read_text(encoding="utf-8")


### PR DESCRIPTION
## 功能说明

- 收紧 auto-merge 失败后的唯一可恢复路径：只有 GitHub 明确返回 PR 已处于 `clean` 状态时允许 fallback。
- fallback 前必须重新查询准确 head SHA，并确认 `policy`、`tests-windows`、`tests-macos` 针对该 SHA 全部成功。
- 仅允许对准确 head SHA 执行 squash merge；其他错误、检查异常或 SHA 变化必须硬停止。

## 变更记录

- `docs/changes/2026-08-07-auto-merge-clean-fallback.md`
- 发布级别：`none`，仅影响 Agent 交付治理，无产品运行时变化。

## 验证证据

- `python scripts/team_policy.py pre-push`：通过。
- Python 全量测试：357 项通过。
- 两个前端脚本 `node --check`：通过。
- 全部 Node 测试：通过。

## 风险

GitHub API 状态不明确时会硬停止，不绕过 required checks。