### PR TITLE
🐞 fix(proxy): 修复请求记录轮询阻塞

### DIFF
--- a/docs/changes/2026-08-11-local-proxy-request-stall.md
+++ b/docs/changes/2026-08-11-local-proxy-request-stall.md
@@ -66,4 +66,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/15

--- a/docs/changes/2026-08-11-local-proxy-request-stall.md
+++ b/docs/changes/2026-08-11-local-proxy-request-stall.md
@@ -1,0 +1,69 @@
++++
+id = "2026-08-11-local-proxy-request-stall"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 本地中转请求记录卡顿修复
+
+## 目标
+
+降低请求记录查询耗时，避免控制台轮询阻塞本地中转的健康接口和流式转发，并让运行中请求的耗时以稳定节奏刷新。
+
+## 现状
+
+请求记录查询使用 `request_history.usage_id` 排除已迁移的旧用量记录，但该字段缺少索引。随着本地历史数据增长，关联子查询会反复扫描请求历史。控制接口又在异步事件循环中直接执行同步 SQLite 查询，请求页每秒轮询时会暂停同一进程中的其他接口和流式响应。前端每轮状态刷新还会先重绘请求列表，再在请求记录返回后再次重绘，造成运行耗时在一秒内多次跳动。
+
+## 设计范围
+
+- 为 `request_history.usage_id` 增加兼容旧数据库的索引迁移。
+- 将控制台的同步数据库读取移到工作线程，避免阻塞 ASGI 事件循环。
+- 批量解析请求历史中的会话名称，减少重复文件状态检查。
+- 限制状态轮询重入，页面不可见时暂停轮询，恢复可见时立即刷新。
+- 请求列表只在请求数据更新后重绘，消除同一轮轮询中的重复耗时刷新。
+
+## 非目标
+
+- 不改变上游供应商路由、重试策略或流式协议。
+- 不改变请求记录保留周期、筛选语义、分页格式或耗时计算口径。
+- 不修改用户现有供应商、会话路由或运行设置。
+
+## 兼容性
+
+现有 SQLite 数据库会在启动时自动创建新增索引，无需数据重建。HTTP 接口字段和前端配置保持不变，旧数据库及现有请求历史继续可读。该改动为向后兼容的缺陷修复，因此发布版本选择 `patch`。
+
+## 风险
+
+首次启动创建索引会产生一次短暂数据库写入；通过 `CREATE INDEX IF NOT EXISTS` 保证重复启动安全。数据库读取移到工作线程后仍由现有锁串行保护，避免并发连接改变数据一致性。页面隐藏时暂停刷新可能让后台标签显示旧状态，恢复可见时立即刷新以消除该差异。
+
+## 测试计划
+
+- 验证新建和旧版 SQLite 数据库都会创建 `request_history_usage_id` 索引。
+- 验证请求记录控制接口执行慢速同步读取时，健康接口仍可响应。
+- 验证请求历史会话名称采用批量解析且返回行为不变。
+- 运行前端 Node 测试，验证轮询重入、页面可见性和请求列表单次渲染行为。
+- 运行完整 Python、Node、语法检查和编译检查。
+
+## 实际改动
+
+- `local_proxy/core.py` 为已有和新建用量数据库增加 `request_history_usage_id` 索引，并将兼容控制入口的状态、恢复历史、Token 历史、请求历史及会话目录读取移入工作线程。
+- `local_proxy/server.py` 将生产统一中转的对应控制接口移入工作线程，避免同步 SQLite 和会话索引读取阻塞流式转发事件循环。
+- `local_proxy/core.py` 对请求历史中的线程 ID 批量解析会话名称，取消逐行重复读取会话索引。
+- `proxy_static/app.js` 串行化状态轮询，后台标签停止轮询并在恢复可见时立即刷新；静默请求记录刷新不再预先重绘，状态渲染也不再重复重绘请求列表。
+- `tests/test_proxy_core.py`、`tests/test_server.py` 和 `tests/local_proxy_requests.test.js` 覆盖索引迁移、查询计划、事件循环响应、批量会话解析和前端轮询渲染行为。
+
+## 验证结果
+
+- `.\.venv\Scripts\python.exe -m unittest tests.test_proxy_core.UsageTests tests.test_server`：19 项通过。
+- `node --test tests\local_proxy_requests.test.js`：10 项通过。
+- `.\.venv\Scripts\python.exe -m unittest discover -s tests -p 'test_*.py'`：392 项通过。
+- `node --test tests\*.test.js`：37 项通过。
+- `node --check proxy_static\app.js`：通过。
+- `.\.venv\Scripts\python.exe -m compileall -q provider_status local_proxy tests`：通过。
+- `git diff --check`：通过，仅输出工作区既有的 LF/CRLF 转换提示。
+- 使用当前真实数据库的 SQLite 备份复测：索引迁移约 18 ms，请求历史查询由修复前约 710 ms 降至 12–15 ms。
+
+## PR
+
+pending

--- a/local_proxy/core.py
+++ b/local_proxy/core.py
@@ -236,6 +236,8 @@ class UsageStore:
                     ON request_history(provider_id, finished_at);
                 CREATE INDEX IF NOT EXISTS request_history_session_key
                     ON request_history(session_key);
+                CREATE INDEX IF NOT EXISTS request_history_usage_id
+                    ON request_history(usage_id);
                 """
             )
             columns = {
@@ -2068,20 +2070,22 @@ def create_proxy_app(
                 default_window="today",
                 allowed_windows=USAGE_WINDOWS,
             )
-            return public_status(window, start_at, end_at)
+            return await asyncio.to_thread(public_status, window, start_at, end_at)
         except ValueError as exc:
             return JSONResponse(status_code=422, content={"detail": str(exc)})
 
     @app.get("/control/api/recovery-history", include_in_schema=False)
     async def control_recovery_history(request: Request):
         if recovery_history_store is None:
-            history = public_status()["retry"]["history"]
+            status = await asyncio.to_thread(public_status)
+            history = status["retry"]["history"]
         else:
             try:
                 limit = int(
                     request.query_params.get("limit", str(RECOVERY_HISTORY_API_LIMIT))
                 )
-                history = recovery_history_store.history(
+                history = await asyncio.to_thread(
+                    recovery_history_store.history,
                     limit=limit,
                     cursor=request.query_params.get("cursor"),
                 )
@@ -2114,7 +2118,8 @@ def create_proxy_app(
         if usage_store is None:
             return JSONResponse(status_code=503, content={"detail": "Token 记录功能不可用"})
         try:
-            history = usage_store.history(
+            history = await asyncio.to_thread(
+                usage_store.history,
                 provider_id=provider_id,
                 window=window,
                 start_at=start_at,
@@ -2149,7 +2154,8 @@ def create_proxy_app(
         ):
             return JSONResponse(status_code=404, content={"detail": "供应商不存在"})
         try:
-            payload = _public_requests(
+            payload = await asyncio.to_thread(
+                _public_requests,
                 router,
                 usage_store,
                 window=window,
@@ -2172,9 +2178,14 @@ def create_proxy_app(
         if session_catalog is None:
             return JSONResponse(status_code=503, content={"detail": "会话路由功能不可用"})
         try:
-            payload = _public_sessions(
+            sessions = await asyncio.to_thread(
+                session_catalog,
+                time.time() - 7 * 24 * 3600,
+            )
+            payload = await asyncio.to_thread(
+                _public_sessions,
                 router,
-                session_catalog(time.time() - 7 * 24 * 3600),
+                sessions,
                 session_name_resolver=session_name_resolver,
             )
         except (OSError, TypeError, ValueError):
@@ -2689,17 +2700,25 @@ def _public_requests(
             query=query,
             cursor=cursor,
         )
+    history_thread_ids = {
+        raw.get("_thread_id")
+        for raw in history["items"]
+        if raw.get("_thread_id") is not None
+    }
+    history_session_names: Mapping[str, str] = {}
+    if session_name_resolver is not None and history_thread_ids:
+        try:
+            history_session_names = session_name_resolver(history_thread_ids)
+        except (OSError, TypeError, ValueError):
+            history_session_names = {}
+
     items: list[dict[str, Any]] = []
     for raw in history["items"]:
         item = dict(raw)
         thread_id = item.pop("_thread_id", None)
-        if thread_id is not None and session_name_resolver is not None:
-            try:
-                current_name = session_name_resolver((thread_id,)).get(thread_id)
-            except (OSError, TypeError, ValueError):
-                current_name = None
-            if current_name:
-                item["session_name"] = current_name
+        current_name = history_session_names.get(thread_id)
+        if current_name:
+            item["session_name"] = current_name
         provider = providers.get(item["provider_id"])
         item["provider_name"] = provider.name if provider else item["provider_id"]
         item["route_provider_id"] = router.session_provider_override(thread_id)

--- a/local_proxy/server.py
+++ b/local_proxy/server.py
@@ -320,17 +320,19 @@ def _register_control_routes(
                 default_window="today",
                 allowed_windows=USAGE_WINDOWS,
             )
-            return public_status(window, start_at, end_at)
+            return await asyncio.to_thread(public_status, window, start_at, end_at)
         except ValueError as exc:
             return JSONResponse(status_code=422, content={"detail": str(exc)})
 
     async def control_recovery_history(request: Request):
         if profile.recovery_history_store is None:
-            history = public_status()["retry"]["history"]
+            status = await asyncio.to_thread(public_status)
+            history = status["retry"]["history"]
         else:
             try:
                 limit = int(request.query_params.get("limit", str(RECOVERY_HISTORY_API_LIMIT)))
-                history = profile.recovery_history_store.history(
+                history = await asyncio.to_thread(
+                    profile.recovery_history_store.history,
                     limit=limit,
                     cursor=request.query_params.get("cursor"),
                 )
@@ -359,7 +361,8 @@ def _register_control_routes(
         if profile.usage_store is None:
             return JSONResponse(status_code=503, content={"detail": "Token 记录功能不可用"})
         try:
-            history = profile.usage_store.history(
+            history = await asyncio.to_thread(
+                profile.usage_store.history,
                 provider_id=provider_id,
                 window=window,
                 start_at=start_at,
@@ -388,7 +391,8 @@ def _register_control_routes(
                 allowed_windows=REQUEST_HISTORY_WINDOWS,
                 max_custom_seconds=REQUEST_HISTORY_HOURS * 3600,
             )
-            payload = _public_requests(
+            payload = await asyncio.to_thread(
+                _public_requests,
                 profile.router,
                 profile.usage_store,
                 window=window,
@@ -410,8 +414,12 @@ def _register_control_routes(
         if profile.session_catalog is None:
             return JSONResponse(status_code=503, content={"detail": "会话路由功能不可用"})
         try:
-            sessions = profile.session_catalog(time.time() - 7 * 24 * 3600)
-            payload = _public_sessions(
+            sessions = await asyncio.to_thread(
+                profile.session_catalog,
+                time.time() - 7 * 24 * 3600,
+            )
+            payload = await asyncio.to_thread(
+                _public_sessions,
                 profile.router,
                 sessions,
                 session_name_resolver=profile.session_name_resolver,

--- a/proxy_static/app.js
+++ b/proxy_static/app.js
@@ -20,6 +20,7 @@ let healthPollTimer = null;
 let toastTimer = null;
 let renderedListSignature = null;
 let statusRequestSequence = 0;
+let statusRequestActive = false;
 let healthRequestSequence = 0;
 let controlRequestActive = false;
 let healthRequestActive = false;
@@ -1321,7 +1322,7 @@ async function readRequests({ reset = false, loadMore = false, refresh = false, 
     requestError = null;
   }
   requestLoading = true;
-  renderRequests();
+  if (!quiet) renderRequests();
   const sequence = ++requestSequence;
   const params = timeRangeParams("requests");
   params.set("status", requestStatus.value);
@@ -2541,11 +2542,11 @@ function renderStatus(status) {
     drainingDetail.textContent = "切换不会中断已经开始的流式响应。";
   }
   renderProviderList();
-  if (!document.querySelector("#requests-view").hidden) renderRequests();
 }
 
-async function readStatus({ quiet = false } = {}) {
-  if (controlRequestActive) return;
+async function readStatus({ quiet = false, force = false } = {}) {
+  if (controlRequestActive || statusRequestActive || (!force && document.hidden)) return;
+  statusRequestActive = true;
   const requestSequence = ++statusRequestSequence;
   try {
     const params = timeRangeParams("usage");
@@ -2565,6 +2566,8 @@ async function readStatus({ quiet = false } = {}) {
   } catch (error) {
     footerMessage.textContent = "无法连接本地中转，服务可能已经退出";
     if (!quiet) showToast("连接失败", "无法读取本地中转状态。", "error");
+  } finally {
+    statusRequestActive = false;
   }
 }
 
@@ -3147,6 +3150,9 @@ window.addEventListener("resize", () => {
   if (usageHistoryPopover.classList.contains("show")) positionUsageHistoryPopover();
   hideHistoryDetail({ force: true });
 });
+document.addEventListener("visibilitychange", () => {
+  if (!document.hidden) void readStatus({ quiet: true, force: true });
+});
 themeMedia.addEventListener("change", () => {
   if (themePreference() === "system") applyTheme("system");
 });
@@ -3156,7 +3162,7 @@ async function initialize() {
   if (!uiConfig.proxy_url) text("#proxy-url", `${window.location.origin}/v1`);
   applyTheme(themePreference());
   renderHealthSourceStatus();
-  readStatus();
+  readStatus({ force: true });
   readRuntimeSettings({ quiet: true });
   pollTimer = window.setInterval(() => readStatus({ quiet: true }), 1000);
   healthPollTimer = window.setInterval(

--- a/tests/local_proxy_requests.test.js
+++ b/tests/local_proxy_requests.test.js
@@ -113,6 +113,41 @@ test("throttles session route refreshes and keeps cached items while refreshing"
   assert.match(source, /readSessionRoutes\(\{ quiet: true, force: true \}\)/);
 });
 
+test("serializes status polling and pauses hidden control tabs", () => {
+  const start = source.indexOf("async function readStatus");
+  const end = source.indexOf("async function readHealthStatus");
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const readStatusSource = source.slice(start, end);
+
+  assert.match(source, /let statusRequestActive = false/);
+  assert.match(
+    readStatusSource,
+    /controlRequestActive \|\| statusRequestActive \|\| \(!force && document\.hidden\)/,
+  );
+  assert.match(readStatusSource, /statusRequestActive = true/);
+  assert.match(readStatusSource, /finally \{\s*statusRequestActive = false/);
+  assert.match(source, /document\.addEventListener\("visibilitychange"/);
+  assert.match(source, /readStatus\(\{ quiet: true, force: true \}\)/);
+});
+
+test("renders quiet request refreshes only after fresh data arrives", () => {
+  const requestStart = source.indexOf("async function readRequests");
+  const requestEnd = source.indexOf("function openAllRequests");
+  const statusStart = source.indexOf("function renderStatus");
+  const statusEnd = source.indexOf("async function readStatus");
+  assert.notEqual(requestStart, -1);
+  assert.notEqual(requestEnd, -1);
+  assert.notEqual(statusStart, -1);
+  assert.notEqual(statusEnd, -1);
+
+  assert.match(
+    source.slice(requestStart, requestEnd),
+    /requestLoading = true;\s*if \(!quiet\) renderRequests\(\)/,
+  );
+  assert.doesNotMatch(source.slice(statusStart, statusEnd), /renderRequests\(\)/);
+});
+
 test("uses route-aware draining request counts", () => {
   const start = source.indexOf("const drainingProviders");
   const end = source.indexOf("renderProviderList();", start);

--- a/tests/test_proxy_core.py
+++ b/tests/test_proxy_core.py
@@ -298,6 +298,32 @@ class UsageTests(unittest.TestCase):
             self.assertTrue(database.is_file())
             self.assertEqual(store.summary("today")["total"]["request_count"], 0)
 
+    def test_existing_database_adds_request_history_usage_index(self) -> None:
+        with closing(sqlite3.connect(self.store.path)) as connection, connection:
+            connection.execute("DROP INDEX request_history_usage_id")
+
+        UsageStore(self.store.path)
+
+        with closing(sqlite3.connect(self.store.path)) as connection:
+            indexes = {
+                row[1]
+                for row in connection.execute("PRAGMA index_list(request_history)")
+            }
+            query_plan = {
+                row[3]
+                for row in connection.execute(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT 1 FROM request_history WHERE usage_id = ?",
+                    (1,),
+                )
+            }
+
+        self.assertIn("request_history_usage_id", indexes)
+        self.assertTrue(
+            any("request_history_usage_id" in step for step in query_plan),
+            query_plan,
+        )
+
     def test_upstream_usage_wins_over_local_estimate(self) -> None:
         capture = UsageCapture(
             b'{"model":"gpt-5","input":"this would be estimated"}',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
-import unittest
+import asyncio
 import tempfile
+import threading
+import time
+import unittest
 from pathlib import Path
 
 import httpx
@@ -282,6 +285,73 @@ class UnifiedProxyAppTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["service"], "codex-provider-hub")
         self.assertEqual(set(response.json()["services"]), {"codex", "claude"})
+
+    async def test_slow_request_history_does_not_block_health_endpoint(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        class SlowUsageStore:
+            def request_history(self, **kwargs):
+                started.set()
+                release.wait(timeout=2)
+                return {
+                    "window": kwargs["window"],
+                    "total_count": 0,
+                    "items": [],
+                    "next_cursor": None,
+                }
+
+        self.codex_profile.usage_store = SlowUsageStore()
+        request_task = asyncio.create_task(
+            self.client.get("/control/codex/api/requests", params={"window": "24h"})
+        )
+        self.assertTrue(await asyncio.to_thread(started.wait, 1))
+        try:
+            health = await asyncio.wait_for(self.client.get("/healthz"), timeout=0.5)
+            self.assertEqual(health.status_code, 200)
+            self.assertFalse(request_task.done())
+        finally:
+            release.set()
+        response = await asyncio.wait_for(request_task, timeout=1)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_request_history_resolves_session_names_in_one_batch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = UsageStore(Path(temp_dir) / "codex.sqlite3")
+            now = time.time()
+            for offset, thread_id in enumerate(("thread-a", "thread-b")):
+                store.record_request(
+                    started_at=now - offset - 1,
+                    finished_at=now - offset,
+                    provider_id="codex-a",
+                    thread_id=thread_id,
+                    session_name="旧名称",
+                    model="gpt-test",
+                    status_code=200,
+                    successful=True,
+                    outcome="succeeded",
+                    retry_count=0,
+                )
+            resolver_calls: list[set[str]] = []
+
+            def resolve_session_names(thread_ids):
+                requested = set(thread_ids)
+                resolver_calls.append(requested)
+                return {thread_id: f"名称-{thread_id}" for thread_id in requested}
+
+            self.codex_profile.usage_store = store
+            self.codex_profile.session_name_resolver = resolve_session_names
+            response = await self.client.get(
+                "/control/codex/api/requests",
+                params={"window": "24h"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(resolver_calls, [{"thread-a", "thread-b"}])
+        self.assertEqual(
+            {item["session_name"] for item in response.json()["items"]},
+            {"名称-thread-a", "名称-thread-b"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更摘要

- 为 `request_history.usage_id` 补充兼容已有数据库的自动索引迁移。
- 将状态、历史和会话目录的同步读取移出 ASGI 事件循环，避免阻塞流式转发。
- 批量解析历史会话名称，串行化前端状态轮询，并在后台标签暂停刷新。
- 消除同一轮轮询内的重复请求列表渲染，稳定运行耗时显示。

## 功能说明

- `docs/changes/2026-08-11-local-proxy-request-stall.md`
- 发布级别：`patch`
- 状态：`verified`

## 风险与兼容性

- 首次启动会通过 `CREATE INDEX IF NOT EXISTS` 创建索引；真实数据库备份实测约 18 ms。
- 现有 HTTP 字段、历史数据、供应商路由和重试行为保持不变。
- 页面隐藏时暂停刷新，恢复可见后立即同步最新状态。

## 验证

- `\.venv\Scripts\python.exe -m unittest discover -s tests -p 'test_*.py'`：392 项通过。
- `node --test tests\*.test.js`：37 项通过。
- `node --check proxy_static\app.js`：通过。
- `\.venv\Scripts\python.exe -m compileall -q provider_status local_proxy tests`：通过。
- `git diff --check origin/main...HEAD`：通过。
- pre-push hook：完整通过。
- 真实数据库备份：请求历史查询由约 710 ms 降至 12–15 ms。