### PR TITLE
📃 docs(readme): 增加 uv 与原生 Python 平级启动说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,31 @@ Apple Silicon（M 系列芯片）Mac 用户可以从 [GitHub Releases](https://g
 
 ### 从源码运行
 
-### 1. 创建 Python 环境
+源码运行提供两种平级方式，可按本机习惯任选其一。
+
+### 1. 使用 uv
+
+先安装 [uv](https://docs.astral.sh/uv/)，然后在仓库根目录执行：
+
+Windows PowerShell：
+
+```powershell
+uv venv --clear .venv
+uv pip install --python .venv\Scripts\python.exe -r requirements-status.txt
+uv run --python .venv\Scripts\python.exe local_proxy_app.py
+```
+
+macOS/Linux：
+
+```bash
+uv venv --clear .venv
+uv pip install --python .venv/bin/python -r requirements-status.txt
+uv run --python .venv/bin/python local_proxy_app.py
+```
+
+默认不会自动打开网页；如需在启动时同时打开两个控制台，可追加 `--open-browser`。
+
+### 2. 使用原生 Python venv
 
 Windows PowerShell：
 

--- a/docs/changes/2026-08-07-uv-startup-instructions.md
+++ b/docs/changes/2026-08-07-uv-startup-instructions.md
@@ -1,0 +1,58 @@
++++
+id = "2026-08-07-uv-startup-instructions"
+type = "docs"
+release_bump = "none"
+status = "verified"
++++
+
+# 增加 uv 启动说明
+
+## 目标
+
+在 README 中提供使用 uv 创建环境、安装依赖并启动项目的可复制命令。
+
+## 现状
+
+README 仅说明使用原生 Python venv 和 pip，未提供 uv 工作流。
+
+## 设计范围
+
+- 在源码运行章节增加 uv 方式。
+- 将 uv 与原生 Python venv 标记为两种平级的可选方式。
+- 提供 Windows、macOS/Linux 的环境创建、依赖安装和启动命令。
+
+## 非目标
+
+- 不修改项目依赖、构建配置或启动逻辑。
+- 不新增 uv lockfile。
+
+## 兼容性
+
+仅修改 README，无运行时、接口、配置、数据或迁移影响。
+
+## 风险
+
+uv 未安装时命令无法执行；README 提供 uv 官方安装入口，并保留原生 Python venv 方式。
+
+## 测试计划
+
+- 检查 README 命令与现有入口和依赖文件一致。
+- 运行完整 Python、Node 和脚本语法验证。
+
+## 实际改动
+
+- `README.md` 的“从源码运行”章节增加 uv 与原生 Python venv 的平级说明，以及 Windows、macOS/Linux 的环境创建、依赖安装和启动命令。
+
+## 验证结果
+
+- `uv --version`：通过，版本 `0.11.6`。
+- `.\.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"`：通过，共 359 项测试。
+- `Get-ChildItem tests -Filter *.test.js | ForEach-Object { node --test $_.FullName; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } }`：通过，共 21 项测试。
+- `node --check proxy_static/app.js`：通过。
+- `node --check provider_status/static/app.js`：通过。
+- `git diff --check`：通过。
+- `Get-NetTCPConnection -LocalPort 17890 -State Listen`：通过，确认项目服务已停止且端口未监听。
+
+## PR
+
+pending


### PR DESCRIPTION
功能修改
- 在 README 增加 Windows 与 macOS/Linux 的 uv 创建环境、安装依赖和启动命令。
- 明确 uv 与原生 Python venv 是平级可选方式。

影响范围
- 仅影响 README 文档和 docs/changes/2026-08-07-uv-startup-instructions.md 变更记录。
- 不修改运行时、依赖、构建配置或启动逻辑。

验证结果
- Python 359 项测试通过，Node 21 项测试通过。
- 两个前端脚本 node --check、git diff --check 通过。
- 已确认项目服务停止且 17890 端口未监听。