### PR TITLE
✨ feat(proxy): 图标字形放大铺满透明画布

### DIFF
--- a/docs/changes/2026-08-12-icon-glyph-size.md
+++ b/docs/changes/2026-08-12-icon-glyph-size.md
@@ -1,0 +1,63 @@
++++
+id = "2026-08-12-icon-glyph-size"
+type = "feature"
+release_bump = "minor"
+status = "verified"
++++
+
+# 图标字形放大铺满画布
+
+## 目标
+
+将托盘与应用图标中的 "CX" 字形从 26px 小字放大到接近铺满 64×64 透明画布，使图标在托盘、任务栏和 Finder 中清晰醒目，视觉尺寸与同类应用图标相当。
+
+## 现状
+
+`create_app_icon()` 使用固定 26px 字号在 64×64 透明画布上绘制 "CX"。透明背景生效后（见 `2026-08-11-transparent-tray-icon`），字形四周留出大量空白，图标看起来比实际更小，在系统托盘中难以辨认。
+
+## 设计范围
+
+- 字号不再固定，按画布尺寸动态计算：从大到小尝试候选字号，选择字形包围盒（含描边）能放入目标区域（64px 画布留出安全边距）的最大字号。
+- 保留白色填充、`#146c73` 描边的配色与居中逻辑；描边宽度随字形尺寸适度加粗，保证大字下描边比例协调。
+- 无 TrueType 字体可用时回退到 Pillow 默认位图字体，居中绘制逻辑不变。
+- 同步调整图标测试：透明背景断言保留，新增字形尺寸下限断言防止字号回退。
+
+## 非目标
+
+- 不改变图标文字内容、配色或透明背景。
+- 不修改构建脚本与 `--write-icon` 输出格式。
+- 不引入新的图标尺寸（仍为 64×64 源图，由 .ico/.icns 容器自行缩放）。
+
+## 兼容性
+
+无接口、配置或数据库变更。仅图标视觉变化，向后兼容，版本选择 `minor`。
+
+## 风险
+
+- 不同平台字体度量差异可能导致字形超出画布被裁切；通过以包围盒实测为准并保留安全边距缓解。
+- 字形变大后透明/不透明像素比例变化，原有"透明像素多于不透明像素"的断言可能失败；调整为透明像素占比下限断言。
+- macOS 字体回退（Helvetica.ttc）度量与 Windows 不同；测试只断言尺寸下限与透明占比，不断言具体字号。
+
+## 测试计划
+
+- 断言生成图标字形包围盒宽度和高度不低于阈值（如 40px），防止回退为小字。
+- 断言四角区域仍为透明、透明像素占比不低于阈值。
+- 运行 Python 单元测试、Node 测试、compileall 与 git diff --check。
+
+## 实际改动
+
+- `local_proxy/application.py` `create_app_icon()`：字号不再固定 26px，改为从大到小扫描候选字号，选择 "CX" 含描边包围盒能放入 64px 画布（边距 3、描边 3）的最大字号；居中计算改用新包围盒的左上角偏移，避免描边导致偏移。
+- `tests/test_local_proxy_app.py`：`test_app_icon_has_transparent_background` 改为断言四角 alpha=0 且全透明像素占比 ≥ 1/4（适应字形放大后像素比例变化）；新增 `test_app_icon_glyphs_fill_canvas`，断言字形包围盒宽 ≥ 44、高 ≥ 28。"CX" 并排时宽度是约束维度（当前 57×35），高度阈值保守以保证跨平台字体度量下仍通过。
+
+## 验证结果
+
+- `.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"`：394 项全部通过。
+- `node --check proxy_static/app.js`、`node --check provider_status/static/app.js`：语法检查通过（未改动 JS）。
+- `node --test tests/*.test.js`：Node 测试全部通过。
+- 生成图标逐像素检查：字形包围盒 57×35（旧版 26px 字号为 39×24），透明像素 2526/4096，四角 alpha=0。
+- `.venv\Scripts\python.exe -m compileall -q local_proxy tests`：通过。
+- `git diff --check`：通过（仅仓库既有 LF/CRLF 转换提示）。
+
+## PR
+
+pending

--- a/local_proxy/application.py
+++ b/local_proxy/application.py
@@ -481,7 +481,11 @@ def create_app_icon() -> Any:
         from PIL import Image, ImageDraw, ImageFont
     except ImportError as exc:
         raise RuntimeError("图标生成需要安装 Pillow") from exc
-    image = Image.new("RGBA", (64, 64), (0, 0, 0, 0))
+    canvas = 64
+    margin = 3
+    stroke_width = 3
+    target = canvas - 2 * margin
+    image = Image.new("RGBA", (canvas, canvas), (0, 0, 0, 0))
     draw = ImageDraw.Draw(image)
     # "segoeuib.ttf" only resolves on Windows; pick a platform-appropriate
     # bold font so the tray/bundle icon keeps crisp glyphs on every OS.
@@ -493,17 +497,26 @@ def create_app_icon() -> Any:
     )
     font = None
     for candidate in font_candidates:
-        try:
-            font = ImageFont.truetype(candidate, 26)
+        # Measure the stroked bbox at each size and keep the largest one that
+        # fits the canvas margin, so the glyphs stay big without clipping on
+        # any platform's font metrics.
+        for font_size in range(target, 8, -1):
+            try:
+                trial = ImageFont.truetype(candidate, font_size)
+            except OSError:
+                break
+            box = draw.textbbox((0, 0), "CX", font=trial, stroke_width=stroke_width)
+            if box[2] - box[0] <= target and box[3] - box[1] <= target:
+                font = trial
+                break
+        if font is not None:
             break
-        except OSError:
-            continue
     if font is None:
         font = ImageFont.load_default()
-    box = draw.textbbox((0, 0), "CX", font=font, stroke_width=2)
-    x = (64 - (box[2] - box[0])) / 2
-    y = (64 - (box[3] - box[1])) / 2 - box[1]
-    draw.text((x, y), "CX", font=font, fill="white", stroke_fill="#146c73", stroke_width=2)
+    box = draw.textbbox((0, 0), "CX", font=font, stroke_width=stroke_width)
+    x = (canvas - (box[2] - box[0])) / 2 - box[0]
+    y = (canvas - (box[3] - box[1])) / 2 - box[1]
+    draw.text((x, y), "CX", font=font, fill="white", stroke_fill="#146c73", stroke_width=stroke_width)
     return image
 
 

--- a/tests/test_local_proxy_app.py
+++ b/tests/test_local_proxy_app.py
@@ -587,20 +587,31 @@ class CodexConfigTests(unittest.TestCase):
         self.assertNotIn("codex_local_proxy_gui.py", script)
 
     def test_app_icon_has_transparent_background(self) -> None:
-        from PIL import Image
-
         icon = local_proxy_app.create_app_icon()
         self.assertEqual(icon.mode, "RGBA")
         self.assertEqual(icon.size, (64, 64))
         alpha = icon.getchannel("A")
         histogram = alpha.histogram()
         opaque = sum(histogram[254:])
-        transparent = sum(histogram[:254])
-        self.assertGreater(transparent, 0)
         self.assertGreater(opaque, 0)
         # The transparent area must cover the outer frame, not just a sliver.
         # The "CX" glyphs are opaque, the surrounding background is transparent.
-        self.assertGreater(transparent, opaque)
+        self.assertGreater(histogram[0], 64 * 64 // 4)
+        for corner in ((0, 0), (63, 0), (0, 63), (63, 63)):
+            self.assertEqual(alpha.getpixel(corner), 0)
+
+    def test_app_icon_glyphs_fill_canvas(self) -> None:
+        icon = local_proxy_app.create_app_icon()
+        bbox = icon.getchannel("A").getbbox()
+        self.assertIsNotNone(bbox)
+        width = bbox[2] - bbox[0]
+        height = bbox[3] - bbox[1]
+        # Glyphs must fill most of the 64px canvas instead of shrinking to a
+        # small wordmark floating on the transparent background. Width is the
+        # binding dimension for "CX" (two caps side by side), so the height
+        # floor is intentionally lower to stay portable across font metrics.
+        self.assertGreaterEqual(width, 44)
+        self.assertGreaterEqual(height, 28)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 目标
将托盘与应用图标中的 "CX" 字形放大到接近铺满 64×64 透明画布，使其在托盘、任务栏和 Finder 中清晰醒目。

## 实际改动
- `local_proxy/application.py` `create_app_icon()`：字号不再固定 26px，改为从大到小扫描候选字号，选择 "CX" 含描边包围盒能放入 64px 画布（边距 3、描边 3）的最大字号；居中改用新包围盒偏移。
- `tests/test_local_proxy_app.py`：透明背景断言改为四角 alpha=0 且全透明像素占比 ≥ 1/4；新增 `test_app_icon_glyphs_fill_canvas` 断言字形包围盒宽 ≥ 44、高 ≥ 28。

## 兼容性
无接口/配置/数据变更，仅图标视觉变化，向后兼容。release_bump = minor。

## 验证结果
- 394 项 Python 单元测试全部通过。
- `node --check` 与 `node --test tests/*.test.js` 通过。
- 逐像素检查：字形包围盒 57×35（旧 39×24），透明像素 2526/4096，四角 alpha=0。

变更说明：docs/changes/2026-08-12-icon-glyph-size.md