### PR TITLE
✨ feat(policy): 新增提交身份用户名白名单门禁

### DIFF
--- a/docs/changes/2026-08-12-commit-identity-whitelist.md
+++ b/docs/changes/2026-08-12-commit-identity-whitelist.md
@@ -1,0 +1,53 @@
++++
+id = "2026-08-12-commit-identity-whitelist"
+type = "feature"
+release_bump = "patch"
+status = "verified"
++++
+
+# 提交身份白名单门禁
+
+## 目标
+
+新增提交身份白名单门禁：只有登记在白名单中的 git 用户名才能提交；一旦作者、提交者或任一 Co-authored-by 身份不在白名单中，则拒绝提交与推送。
+
+## 现状
+
+策略只校验分支名、暂存路径、变更说明与提交信息格式，不校验提交身份，导致非项目成员身份（例如公司内网身份）可能混入提交。
+
+## 设计范围
+
+- 在 `scripts/team_policy.py` 新增 `ALLOWED_COMMIT_NAMES` 白名单与 `validate_commit_identities`。
+- `pre-commit` 校验 author 与 committer 用户名。
+- `commit-msg` 校验 author、committer 及全部 Co-authored-by 用户名。
+- `validate-pr` 对推送区间内每个提交校验 author、committer 及 Co-authored-by 用户名。
+- 白名单基于用户名而非邮箱，避免把成员邮箱写入仓库对外暴露。
+
+## 非目标
+
+不改写既有历史提交，不引入远端身份服务，不新增审批流程。
+
+## 兼容性
+
+无运行时影响；仅作用于本地 git 钩子与 PR 策略校验。白名单为项目当前成员用户名，新增成员需更新常量。
+
+## 风险
+
+用户名可被伪造，门禁强度弱于签名校验；缓解方式是配合远端 ruleset 与 PR 必需检查共同约束。白名单遗漏合法成员会阻断其提交，通过更新常量解决。
+
+## 测试计划
+
+运行 `python -m unittest discover -s tests -p test_*.py`，覆盖白名单接受、任一身份越界拒绝、用户名与 Co-authored-by 解析。
+
+## 实际改动
+
+- `scripts/team_policy.py`：新增 `ALLOWED_COMMIT_NAMES`、`COAUTHOR_RE`、`_extract_name`、`_coauthor_names`、`validate_commit_identities`；在 `command_pre_commit`、新增的 `command_commit_msg`、`validate_pr` 中接入身份校验。
+- `tests/test_team_policy.py`：新增白名单接受、越界拒绝、用户名/Co-authored-by 解析用例。
+
+## 验证结果
+
+`python -m unittest discover -s tests -p "test_team_policy.py"` 全部 25 项通过。
+
+## PR
+
+pending

--- a/scripts/team_policy.py
+++ b/scripts/team_policy.py
@@ -48,6 +48,16 @@ BLOCKED_PATH_PATTERNS = (
     re.compile(r"\.(?:sqlite3?|db)(?:-|$)"),
     re.compile(r"\.(?:pem|key|p12|pfx)$"),
 )
+ALLOWED_COMMIT_NAMES = frozenset(
+    (
+        "moye12325",
+        "loongkkk",
+        "LOONGKKK\\loong",
+        "Gao Yiheng",
+        "GitHub",
+    )
+)
+COAUTHOR_RE = re.compile(r"(?im)^\s*co-authored-by:\s*([^<]+?)\s*<[^>]+>\s*$")
 
 
 class PolicyError(RuntimeError):
@@ -350,6 +360,31 @@ def validate_staged_paths(paths: list[str]) -> None:
             raise PolicyError(f"禁止提交生成产物、敏感文件或本地状态：{path}")
 
 
+def _extract_name(ident: str) -> str:
+    name = ident.split("<", 1)[0].strip()
+    if not name:
+        raise PolicyError(f"无法从身份中解析用户名：{ident!r}")
+    return name
+
+
+def _coauthor_names(message: str) -> list[str]:
+    return [match.group(1).strip() for match in COAUTHOR_RE.finditer(message)]
+
+
+def validate_commit_identities(identities: list[tuple[str, str]]) -> None:
+    disallowed = [
+        (role, name)
+        for role, name in identities
+        if name not in ALLOWED_COMMIT_NAMES
+    ]
+    if disallowed:
+        detail = "；".join(f"{role} {name}" for role, name in disallowed)
+        raise PolicyError(
+            f"提交身份不在白名单中，拒绝提交：{detail}。"
+            "仅允许项目已登记的提交者用户名"
+        )
+
+
 def run_git(args: list[str], *, check: bool = True) -> str:
     result = subprocess.run(
         ["git", *args],
@@ -399,10 +434,19 @@ def validate_pr(base: str, head: str) -> None:
     _require_change_record(paths, records)
     for record in records:
         validate_change_record(record, required_status="verified")
-    messages = run_git(["log", "--format=%B%x00", f"{base}..{head}"])
-    for message in (part.strip() for part in messages.split("\x00")):
-        if message:
-            validate_commit_message(message)
+    messages = run_git(["log", "--format=%an%x1f%cn%x1f%B%x00", f"{base}..{head}"])
+    for entry in (part for part in messages.split("\x00") if part.strip()):
+        author_name, committer_name, message = entry.split("\x1f", 2)
+        message = message.strip()
+        if not message:
+            continue
+        validate_commit_message(message)
+        identities = [
+            ("author", author_name.strip()),
+            ("committer", committer_name.strip()),
+        ]
+        identities.extend(("co-author", name) for name in _coauthor_names(message))
+        validate_commit_identities(identities)
 
 
 def run_full_verification() -> None:
@@ -426,10 +470,27 @@ def command_install_hooks() -> None:
 
 def command_pre_commit() -> None:
     validate_branch_name(run_git(["branch", "--show-current"]))
+    validate_commit_identities(
+        [
+            ("author", _extract_name(run_git(["var", "GIT_AUTHOR_IDENT"]))),
+            ("committer", _extract_name(run_git(["var", "GIT_COMMITTER_IDENT"]))),
+        ]
+    )
     paths = _paths_from_git(["diff", "--cached", "--name-only"])
     validate_staged_paths(paths)
     records = [parse_change_record(Path(path)) for path in paths if path.startswith("docs/changes/") and path.endswith(".md") and not path.endswith("template.md")]
     _require_change_record(paths, records)
+
+
+def command_commit_msg(path: str) -> None:
+    message = Path(path).read_text(encoding="utf-8")
+    validate_commit_message(message)
+    identities = [
+        ("author", _extract_name(run_git(["var", "GIT_AUTHOR_IDENT"]))),
+        ("committer", _extract_name(run_git(["var", "GIT_COMMITTER_IDENT"]))),
+    ]
+    identities.extend(("co-author", name) for name in _coauthor_names(message))
+    validate_commit_identities(identities)
 
 
 def command_pre_push(stdin: str) -> None:
@@ -479,7 +540,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "pre-commit":
             command_pre_commit()
         elif args.command == "commit-msg":
-            validate_commit_message(Path(args.path).read_text(encoding="utf-8"))
+            command_commit_msg(args.path)
         elif args.command == "pre-push":
             command_pre_push(sys.stdin.read())
         elif args.command == "validate-pr":

--- a/tests/test_team_policy.py
+++ b/tests/test_team_policy.py
@@ -12,9 +12,12 @@ from scripts.team_policy import (
     parse_change_record,
     validate_branch_name,
     validate_change_record,
+    validate_commit_identities,
     validate_commit_message,
     validate_staged_paths,
     render_release_notes,
+    _coauthor_names,
+    _extract_name,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -167,6 +170,47 @@ class GitPolicyTests(unittest.TestCase):
                 PolicyError, "禁止提交"
             ):
                 validate_staged_paths([path])
+
+    def test_accepts_whitelisted_commit_identities(self) -> None:
+        validate_commit_identities(
+            [("author", "moye12325"), ("committer", "GitHub")]
+        )
+        validate_commit_identities(
+            [
+                ("author", "loongkkk"),
+                ("committer", "LOONGKKK\\loong"),
+                ("co-author", "Gao Yiheng"),
+            ]
+        )
+
+    def test_rejects_any_identity_outside_whitelist(self) -> None:
+        with self.assertRaisesRegex(PolicyError, "BY250013"):
+            validate_commit_identities(
+                [("author", "moye12325"), ("committer", "BY250013")]
+            )
+        with self.assertRaisesRegex(PolicyError, "BY250013"):
+            validate_commit_identities(
+                [
+                    ("author", "moye12325"),
+                    ("committer", "moye12325"),
+                    ("co-author", "BY250013"),
+                ]
+            )
+
+    def test_extracts_name_and_coauthor_names(self) -> None:
+        self.assertEqual(
+            _extract_name("moye12325 <gengkang12325@gmail.com> 1700000000 +0800"),
+            "moye12325",
+        )
+        self.assertEqual(_extract_name("LOONGKKK\\loong <loongk@vip.qq.com>"), "LOONGKKK\\loong")
+        self.assertEqual(
+            _coauthor_names(
+                "✨ feat(policy): 门禁\n\n功能修改\n- x\n\n"
+                "Co-authored-by: Gao Yiheng <gaoyiheng2021@gmail.com>\n"
+                "Co-authored-by: BY250013 <gkk@originqc.com>\n"
+            ),
+            ["Gao Yiheng", "BY250013"],
+        )
 
 
 class RepositoryGovernanceAssetTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- 新增提交身份白名单门禁：只有白名单中的 git 用户名可提交。
- author、committer 或任一 Co-authored-by 身份越界即拒绝提交与推送。
- 基于用户名而非邮箱，避免把成员邮箱写入仓库对外暴露。

## 改动
- `scripts/team_policy.py`：`ALLOWED_COMMIT_NAMES`、`validate_commit_identities`，接入 `pre-commit`/`commit-msg`/`validate-pr`。
- `tests/test_team_policy.py`：白名单接受、越界拒绝、用户名与 Co-authored-by 解析用例。
- `docs/changes/2026-08-12-commit-identity-whitelist.md`：变更说明。

## Test plan
- [x] python -m unittest discover -s tests -p "test_team_policy.py"（25 项通过）