### PR TITLE
feat(proxy): Windows 便携版在线更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![FastAPI](https://img.shields.io/badge/FastAPI-0.115%2B-009688?style=flat-square)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-4b5563?style=flat-square)
 ![README](https://img.shields.io/badge/README-%E4%B8%AD%E6%96%87-c43d3d?style=flat-square)
-[![Release](https://img.shields.io/github/v/release/loongkkk/codex-provider-hub?style=flat-square)](https://github.com/loongkkk/codex-provider-hub/releases/latest)
+[![Release](https://img.shields.io/github/v/release/AI-Routing-Research-Institute/codex-provider-hub?style=flat-square)](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest)
 
 </div>
 
@@ -88,19 +88,19 @@ Provider Config ──► Probe Worker ──► SQLite ──► Status Web
 
 ### Windows 便携版（推荐）
 
-Windows x64 用户可以从 [GitHub Releases](https://github.com/loongkkk/codex-provider-hub/releases/latest) 下载便携版，无需安装 Python 或项目依赖。文件名暂时保留 `CodexLocalProxy`，程序会启动一个同时支持 Codex 与 Claude Code 的本地中转服务：
+Windows x64 用户可以从 [GitHub Releases](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest) 下载便携版，无需安装 Python 或项目依赖。文件名暂时保留 `CodexLocalProxy`，程序会启动一个同时支持 Codex 与 Claude Code 的本地中转服务：
 
-- [下载 `CodexLocalProxy-win-x64.exe`](https://github.com/loongkkk/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe)
-- [下载 SHA-256 校验文件](https://github.com/loongkkk/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe.sha256)
+- [下载 `CodexLocalProxy-win-x64.exe`](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe)
+- [下载 SHA-256 校验文件](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe.sha256)
 
 下载后直接双击 EXE，程序会静默启动并常驻 Windows 通知区域，不会自动打开网页。右键托盘图标可分别打开 Codex 和 Claude Code 控制台，也可开启当前用户的“开机自启”。使用前需要先安装并配置 CC Switch，确保当前用户目录存在 `~/.cc-switch/cc-switch.db`。共享配置与 Codex/Claude Code 的独立状态均保存在 `~/.codex-local-proxy/`。
 
 ### macOS 便携版
 
-Apple Silicon（M 系列芯片）Mac 用户可以从 [GitHub Releases](https://github.com/loongkkk/codex-provider-hub/releases/latest) 下载 `.zip` 便携版，无需安装 Python 或项目依赖。文件名暂时保留 `CodexLocalProxy`，程序会启动一个同时支持 Codex 与 Claude Code 的本地中转服务：
+Apple Silicon（M 系列芯片）Mac 用户可以从 [GitHub Releases](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest) 下载 `.zip` 便携版，无需安装 Python 或项目依赖。文件名暂时保留 `CodexLocalProxy`，程序会启动一个同时支持 Codex 与 Claude Code 的本地中转服务：
 
-- [下载 `CodexLocalProxy-macos-arm64.zip`](https://github.com/loongkkk/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip)
-- [下载 SHA-256 校验文件](https://github.com/loongkkk/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip.sha256)
+- [下载 `CodexLocalProxy-macos-arm64.zip`](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip)
+- [下载 SHA-256 校验文件](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip.sha256)
 
 使用步骤：
 

--- a/docs/changes/2026-08-12-windows-online-update.md
+++ b/docs/changes/2026-08-12-windows-online-update.md
@@ -1,0 +1,57 @@
++++
+id = "2026-08-12-windows-online-update"
+type = "feature"
+release_bump = "minor"
+status = "verified"
++++
+
+# Windows 在线更新
+
+## 目标
+
+为便携版提供在线更新能力：Windows 便携版可检测到 GitHub 最新发布、下载并校验新版 exe，退出后由助手替换旧文件并自动重启到新版本；其他平台检测到新版本后引导手动下载。
+
+## 现状
+
+程序仅有内置 `APP_VERSION`，没有任何检测最新发布或自更新的逻辑，用户只能自行去 Releases 页面手动下载替换。
+
+## 设计范围
+
+- 新增 `local_proxy/updater.py`：查询 `releases/latest`、semver 比对、按平台选择产物、流式下载并做 SHA-256 校验。
+- 托盘新增「检查更新／更新到 vX.Y.Z」菜单项与通知；启动后后台静默检测一次。
+- Windows 冻结版全自动闭环：下载校验 → 退出 → 由新版二进制以 `--finalize-update` 等待旧进程退出后替换目标文件并重启，失败回滚 `.bak`。
+- 非 Windows 或源码运行：仅检测提示，跳转 Releases 页面手动更新。
+- 修正 README 的仓库地址为实际发布仓库 `AI-Routing-Research-Institute/codex-provider-hub`。
+
+## 非目标
+
+不做 macOS 就地自更新（依赖后续代码签名与公证），不做增量更新，不做静默强制升级。
+
+## 兼容性
+
+无运行时协议影响。新增托盘菜单项与后台检测线程；更新产物与校验文件写入 `~/.codex-local-proxy/updates/`。检测使用 GitHub 匿名 API（60次/小时/IP），失败静默降级。
+
+## 风险
+
+- 便携版信任模型为 HTTPS + GitHub 发布完整性 + SHA-256 校验，无代码签名；校验不通过即中止。
+- 替换失败时回滚旧版本 `.bak` 并提示。
+- API 限流或离线时检测失败，仅静默跳过，不影响主服务。
+
+## 测试计划
+
+`python -m unittest discover -s tests -p test_*.py`，覆盖 semver 比对、发布解析、SHA-256 文档解析与文件校验、注入客户端的检测、助手命令构造与进程存活判定；并修正既有托盘菜单测试。
+
+## 实际改动
+
+- `local_proxy/updater.py`：新增 `UpdateInfo`、`parse_version`/`is_newer`、`parse_release`、`fetch_latest_release`/`check_for_update`、`parse_sha256_document`/`verify_file_sha256`、`download_asset`。
+- `local_proxy/application.py`：新增 `update_supported`、`updates_directory`、`_spawn_detached`、`_process_alive`、`launch_update_helper`、`finalize_update`、`_relaunch_target`；托盘接入检查/更新菜单、通知与后台检测；`run_local_proxy_server` 退出后触发助手；`main` 新增隐藏 `--finalize-update/--target/--wait-pid`。
+- `tests/test_updater.py`：新增更新逻辑单测；`tests/test_local_proxy_app.py`：适配新增菜单项与 `enabled` 参数。
+- `README.md`：仓库地址改为实际发布仓库。
+
+## 验证结果
+
+`python -m unittest discover -s tests -p "test_*.py"` 全量通过（含新增 13 项 updater 用例）。
+
+## PR
+
+pending

--- a/local_proxy/application.py
+++ b/local_proxy/application.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -353,7 +354,10 @@ def run_local_proxy_server(
     finally:
         if started:
             server.stop()
-    if restart_requested:
+    update_apply_path = active_tray_holder.get("update_apply_path")
+    if update_apply_path:
+        launch_update_helper(Path(update_apply_path))
+    elif restart_requested:
         launch_replacement_process()
     return 0
 
@@ -371,6 +375,13 @@ def _run_tray(
 
     image = create_app_icon()
     restart_requested = threading.Event()
+    update_state: dict[str, Any] = {"info": None, "busy": False}
+
+    def _notify(icon: Any, message: str) -> None:
+        try:
+            icon.notify(message, "Codex 本地中转")
+        except (AttributeError, NotImplementedError, OSError):
+            pass
 
     def open_codex_console(icon: Any = None, item: Any = None) -> None:
         webbrowser.open(codex_control_url)
@@ -410,6 +421,73 @@ def _run_tray(
         server.request_stop()
         icon.stop()
 
+    def update_menu_text(item: Any = None) -> str:
+        if update_state["busy"]:
+            return "正在更新…"
+        info = update_state["info"]
+        if info is not None and info.has_update:
+            return f"更新到 {info.latest_version}"
+        return "检查更新"
+
+    def update_menu_enabled(item: Any = None) -> bool:
+        return not update_state["busy"]
+
+    def _run_update_check(icon: Any, *, announce: bool) -> None:
+        from local_proxy import updater
+
+        try:
+            info = updater.check_for_update(APP_VERSION)
+        except updater.UpdateError as exc:
+            if announce:
+                _notify(icon, f"检查更新失败：{exc}")
+            return
+        update_state["info"] = info
+        icon.update_menu()
+        if info.has_update:
+            _notify(icon, f"发现新版本 {info.latest_version}，点击托盘菜单更新。")
+        elif announce:
+            _notify(icon, "当前已是最新版本。")
+
+    def _run_update_apply(icon: Any) -> None:
+        from local_proxy import updater
+
+        info = update_state["info"]
+        if info is None or not info.has_update:
+            return
+        if not update_supported():
+            webbrowser.open(info.release_url)
+            _notify(icon, "当前平台请手动下载安装最新版本。")
+            return
+        update_state["busy"] = True
+        icon.update_menu()
+        try:
+            new_executable = updater.download_asset(info, updates_directory())
+        except updater.UpdateError as exc:
+            update_state["busy"] = False
+            icon.update_menu()
+            _notify(icon, f"更新失败：{exc}")
+            return
+        tray_holder["update_apply_path"] = str(new_executable)
+        _notify(icon, "更新已就绪，正在重启到新版本…")
+        server.request_stop()
+        icon.stop()
+
+    def on_update_clicked(icon: Any, item: Any = None) -> None:
+        if update_state["busy"]:
+            return
+        info = update_state["info"]
+        if info is not None and info.has_update:
+            threading.Thread(
+                target=_run_update_apply, args=(icon,), daemon=True
+            ).start()
+        else:
+            threading.Thread(
+                target=_run_update_check,
+                args=(icon,),
+                kwargs={"announce": True},
+                daemon=True,
+            ).start()
+
     menu_items = [
         pystray.MenuItem(
             "默认打开 Codex 控制台",
@@ -434,6 +512,12 @@ def _run_tray(
         )
     menu_items.extend(
         (
+            pystray.MenuItem(
+                update_menu_text,
+                on_update_clicked,
+                enabled=update_menu_enabled,
+            ),
+            pystray.Menu.SEPARATOR,
             pystray.MenuItem("重启本地中转", restart_proxy),
             pystray.MenuItem("退出本地中转", exit_proxy),
         )
@@ -446,6 +530,12 @@ def _run_tray(
         menu=pystray.Menu(*menu_items),
     )
     tray_holder["icon"] = icon
+
+    def _startup_check() -> None:
+        time.sleep(3)
+        _run_update_check(icon, announce=False)
+
+    threading.Thread(target=_startup_check, daemon=True).start()
     icon.run()
     return restart_requested.is_set()
 
@@ -474,6 +564,102 @@ def launch_replacement_process() -> None:
     else:
         options["start_new_session"] = True
     subprocess.Popen(command, **options)
+
+
+def update_supported() -> bool:
+    return sys.platform == "win32" and bool(getattr(sys, "frozen", False))
+
+
+def updates_directory() -> Path:
+    return data_directory() / "updates"
+
+
+def _spawn_detached(command: list[str], working_directory: Path) -> None:
+    options: dict[str, Any] = {
+        "cwd": str(working_directory),
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if os.name == "nt":
+        options["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "DETACHED_PROCESS", 0)
+        )
+    else:
+        options["start_new_session"] = True
+    subprocess.Popen(command, **options)
+
+
+def _process_alive(pid: int) -> bool:
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except (OSError, ProcessLookupError):
+            return False
+        return True
+    import ctypes
+
+    still_active = 259
+    query_limited = 0x1000
+    kernel32 = ctypes.windll.kernel32
+    handle = kernel32.OpenProcess(query_limited, False, pid)
+    if not handle:
+        return False
+    try:
+        exit_code = ctypes.c_ulong()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def launch_update_helper(new_executable: Path) -> None:
+    """Hand the running new-version binary the swap-then-relaunch job."""
+
+    target = Path(sys.executable).resolve()
+    command = [
+        str(new_executable),
+        "--finalize-update",
+        "--target",
+        str(target),
+        "--wait-pid",
+        str(os.getpid()),
+    ]
+    _spawn_detached(command, new_executable.parent)
+
+
+def finalize_update(target: Path, wait_pid: int) -> int:
+    """Wait for the old process to exit, swap in this binary, then relaunch it."""
+
+    deadline = time.time() + 60
+    while wait_pid > 0 and time.time() < deadline and _process_alive(wait_pid):
+        time.sleep(0.5)
+    source = Path(sys.executable).resolve()
+    target = target.resolve()
+    backup = target.with_name(target.name + ".bak")
+    try:
+        if target.exists():
+            shutil.copy2(target, backup)
+        shutil.copy2(source, target)
+    except OSError as exc:
+        if backup.exists():
+            try:
+                shutil.copy2(backup, target)
+            except OSError:
+                pass
+        show_startup_error(f"更新失败，已保留原版本：{exc}")
+        _relaunch_target(target)
+        return 1
+    _relaunch_target(target)
+    backup.unlink(missing_ok=True)
+    return 0
+
+
+def _relaunch_target(target: Path) -> None:
+    _spawn_detached([str(target), "--no-browser", "--tray"], target.parent)
 
 
 def create_app_icon() -> Any:
@@ -548,8 +734,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--tray", action="store_true")
     parser.add_argument("--smoke-test", action="store_true")
     parser.add_argument("--write-icon", type=Path)
+    parser.add_argument("--finalize-update", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--target", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--wait-pid", type=int, help=argparse.SUPPRESS)
     parser.add_argument("--version", action="version", version=APP_VERSION)
     args = parser.parse_args(argv)
+    if args.finalize_update:
+        if args.target is None:
+            print("--finalize-update 需要 --target", file=sys.stderr)
+            return 1
+        return finalize_update(args.target, args.wait_pid or 0)
     if args.write_icon is not None:
         try:
             write_app_icon(args.write_icon)

--- a/local_proxy/updater.py
+++ b/local_proxy/updater.py
@@ -1,0 +1,197 @@
+"""Online update: query GitHub Releases, compare versions, download and verify artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+
+RELEASE_OWNER = "AI-Routing-Research-Institute"
+RELEASE_REPO = "codex-provider-hub"
+LATEST_RELEASE_API = (
+    f"https://api.github.com/repos/{RELEASE_OWNER}/{RELEASE_REPO}/releases/latest"
+)
+RELEASES_PAGE = f"https://github.com/{RELEASE_OWNER}/{RELEASE_REPO}/releases/latest"
+WINDOWS_ASSET = "CodexLocalProxy-win-x64.exe"
+MACOS_ASSET = "CodexLocalProxy-macos-arm64.zip"
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+_USER_AGENT = "codex-provider-hub-updater"
+_CHUNK_SIZE = 1 << 16
+
+
+class UpdateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+    current_version: str
+    latest_version: str
+    has_update: bool
+    release_url: str
+    notes: str
+    asset_name: str | None
+    asset_url: str | None
+    sha256_url: str | None
+    published_at: str | None
+
+
+def parse_version(text: str) -> tuple[int, int, int]:
+    match = _VERSION_RE.search(text or "")
+    if match is None:
+        raise UpdateError(f"无法解析版本号：{text!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    return parse_version(candidate) > parse_version(current)
+
+
+def platform_asset_name() -> str | None:
+    if sys.platform == "win32":
+        return WINDOWS_ASSET
+    if sys.platform == "darwin":
+        return MACOS_ASSET
+    return None
+
+
+def _select_asset(assets: list, name: str) -> str | None:
+    for asset in assets:
+        if isinstance(asset, dict) and asset.get("name") == name:
+            url = asset.get("browser_download_url")
+            return str(url) if url else None
+    return None
+
+
+def parse_release(
+    payload: dict,
+    current_version: str,
+    *,
+    asset_name: str | None = None,
+) -> UpdateInfo:
+    tag = str(payload.get("tag_name") or "").strip()
+    if not tag:
+        raise UpdateError("发布信息缺少 tag_name")
+    latest_version = tag.lstrip("vV")
+    assets = payload.get("assets") if isinstance(payload.get("assets"), list) else []
+    wanted = asset_name or platform_asset_name()
+    asset_url = _select_asset(assets, wanted) if wanted else None
+    sha256_url = _select_asset(assets, f"{wanted}.sha256") if wanted else None
+    try:
+        newer = is_newer(latest_version, current_version)
+    except UpdateError:
+        newer = False
+    return UpdateInfo(
+        current_version=current_version,
+        latest_version=latest_version,
+        has_update=newer and asset_url is not None and sha256_url is not None,
+        release_url=str(payload.get("html_url") or RELEASES_PAGE),
+        notes=str(payload.get("body") or "").strip(),
+        asset_name=wanted,
+        asset_url=asset_url,
+        sha256_url=sha256_url,
+        published_at=payload.get("published_at"),
+    )
+
+
+def fetch_latest_release(*, timeout: float = 10.0, client=None) -> dict:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": _USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        if client is not None:
+            response = client.get(LATEST_RELEASE_API, headers=headers, timeout=timeout)
+        else:
+            response = httpx.get(
+                LATEST_RELEASE_API,
+                headers=headers,
+                timeout=timeout,
+                follow_redirects=True,
+            )
+    except httpx.HTTPError as exc:
+        raise UpdateError(f"检查更新失败：{exc}") from exc
+    if response.status_code != 200:
+        raise UpdateError(f"检查更新失败：HTTP {response.status_code}")
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise UpdateError("检查更新失败：响应不是有效 JSON") from exc
+    if not isinstance(payload, dict):
+        raise UpdateError("检查更新失败：响应格式异常")
+    return payload
+
+
+def check_for_update(
+    current_version: str,
+    *,
+    timeout: float = 10.0,
+    client=None,
+    asset_name: str | None = None,
+) -> UpdateInfo:
+    payload = fetch_latest_release(timeout=timeout, client=client)
+    return parse_release(payload, current_version, asset_name=asset_name)
+
+
+def parse_sha256_document(text: str) -> str:
+    parts = text.strip().split()
+    token = parts[0].lower() if parts else ""
+    if len(token) != 64 or any(ch not in "0123456789abcdef" for ch in token):
+        raise UpdateError("SHA-256 校验文件格式不正确")
+    return token
+
+
+def verify_file_sha256(path: Path, expected_hex: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    actual = digest.hexdigest()
+    if actual.lower() != expected_hex.lower():
+        raise UpdateError(f"SHA-256 校验失败：期望 {expected_hex}，实际 {actual}")
+    return actual
+
+
+def download_asset(
+    info: UpdateInfo,
+    destination_dir: Path,
+    *,
+    timeout: float = 120.0,
+) -> Path:
+    if info.asset_url is None or info.sha256_url is None or info.asset_name is None:
+        raise UpdateError("当前平台没有可用的发布产物")
+    destination_dir = Path(destination_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    target = destination_dir / info.asset_name
+    temporary = target.with_name(target.name + ".part")
+    temporary.unlink(missing_ok=True)
+    try:
+        with httpx.stream(
+            "GET", info.asset_url, timeout=timeout, follow_redirects=True
+        ) as response:
+            if response.status_code != 200:
+                raise UpdateError(f"下载失败：HTTP {response.status_code}")
+            with open(temporary, "wb") as handle:
+                for chunk in response.iter_bytes(_CHUNK_SIZE):
+                    handle.write(chunk)
+        sha_response = httpx.get(
+            info.sha256_url, timeout=30.0, follow_redirects=True
+        )
+        if sha_response.status_code != 200:
+            raise UpdateError(f"下载校验文件失败：HTTP {sha_response.status_code}")
+        verify_file_sha256(temporary, parse_sha256_document(sha_response.text))
+        target.unlink(missing_ok=True)
+        temporary.replace(target)
+    except httpx.HTTPError as exc:
+        temporary.unlink(missing_ok=True)
+        raise UpdateError(f"下载失败：{exc}") from exc
+    except UpdateError:
+        temporary.unlink(missing_ok=True)
+        raise
+    return target

--- a/tests/test_local_proxy_app.py
+++ b/tests/test_local_proxy_app.py
@@ -337,15 +337,18 @@ class CodexConfigTests(unittest.TestCase):
                 default=False,
                 checked=None,
                 visible=True,
+                enabled=None,
             ):
-                self.label = label
+                display = label() if callable(label) else label
+                self.label = display
                 self.action = action
                 self.default = default
                 self.checked = checked
                 self.visible = visible
+                self.enabled = enabled
                 if visible:
-                    menu_labels.append(label)
-                menu_items_by_label[label] = self
+                    menu_labels.append(display)
+                menu_items_by_label[display] = self
 
         class FakeMenu:
             SEPARATOR = object()
@@ -398,7 +401,7 @@ class CodexConfigTests(unittest.TestCase):
         server.request_stop.assert_called_once_with()
         self.assertEqual(
             menu_labels,
-            ["打开控制台", "打开 Claude Code 控制台", "开机自启", "重启本地中转", "退出本地中转"],
+            ["打开控制台", "打开 Claude Code 控制台", "开机自启", "检查更新", "重启本地中转", "退出本地中转"],
         )
         self.assertTrue(auto_start_checked)
         self.assertFalse(visible_open_item.default)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,148 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_proxy import updater
+from local_proxy.updater import UpdateError
+
+
+class FakeResponse:
+    def __init__(self, *, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self, response):
+        self._response = response
+
+    def get(self, url, headers=None, timeout=None):
+        return self._response
+
+
+def release_payload(tag, *, asset="CodexLocalProxy-win-x64.exe", with_sha=True):
+    assets = [{"name": asset, "browser_download_url": f"https://example/{asset}"}]
+    if with_sha:
+        assets.append(
+            {"name": f"{asset}.sha256", "browser_download_url": f"https://example/{asset}.sha256"}
+        )
+    return {"tag_name": tag, "assets": assets, "html_url": "https://example/release", "body": "notes"}
+
+
+class VersionTests(unittest.TestCase):
+    def test_parses_and_compares_versions(self):
+        self.assertEqual(updater.parse_version("v0.7.1"), (0, 7, 1))
+        self.assertEqual(updater.parse_version("0.7.1"), (0, 7, 1))
+        self.assertTrue(updater.is_newer("0.7.2", "0.7.1"))
+        self.assertTrue(updater.is_newer("v1.0.0", "0.9.9"))
+        self.assertFalse(updater.is_newer("0.7.1", "0.7.1"))
+        self.assertFalse(updater.is_newer("0.7.0", "0.7.1"))
+
+    def test_rejects_unparseable_version(self):
+        with self.assertRaisesRegex(UpdateError, "版本号"):
+            updater.parse_version("release")
+
+
+class ParseReleaseTests(unittest.TestCase):
+    def test_flags_update_when_newer_with_assets(self):
+        info = updater.parse_release(
+            release_payload("v0.7.2"), "0.7.1", asset_name="CodexLocalProxy-win-x64.exe"
+        )
+        self.assertTrue(info.has_update)
+        self.assertEqual(info.latest_version, "0.7.2")
+        self.assertTrue(info.asset_url.endswith("CodexLocalProxy-win-x64.exe"))
+        self.assertTrue(info.sha256_url.endswith(".sha256"))
+
+    def test_no_update_when_same_version(self):
+        info = updater.parse_release(
+            release_payload("v0.7.1"), "0.7.1", asset_name="CodexLocalProxy-win-x64.exe"
+        )
+        self.assertFalse(info.has_update)
+
+    def test_no_update_when_asset_missing(self):
+        payload = release_payload("v0.7.2", asset="OtherName.exe")
+        info = updater.parse_release(
+            payload, "0.7.1", asset_name="CodexLocalProxy-win-x64.exe"
+        )
+        self.assertFalse(info.has_update)
+        self.assertIsNone(info.asset_url)
+
+    def test_missing_tag_raises(self):
+        with self.assertRaisesRegex(UpdateError, "tag_name"):
+            updater.parse_release({"assets": []}, "0.7.1")
+
+
+class FetchTests(unittest.TestCase):
+    def test_check_for_update_uses_injected_client(self):
+        client = FakeClient(FakeResponse(payload=release_payload("v0.8.0")))
+        info = updater.check_for_update(
+            "0.7.1", client=client, asset_name="CodexLocalProxy-win-x64.exe"
+        )
+        self.assertTrue(info.has_update)
+        self.assertEqual(info.latest_version, "0.8.0")
+
+    def test_non_200_raises(self):
+        client = FakeClient(FakeResponse(status_code=404))
+        with self.assertRaisesRegex(UpdateError, "HTTP 404"):
+            updater.check_for_update("0.7.1", client=client)
+
+
+class Sha256Tests(unittest.TestCase):
+    def test_parses_hash_document_forms(self):
+        digest = "a" * 64
+        self.assertEqual(updater.parse_sha256_document(digest), digest)
+        self.assertEqual(updater.parse_sha256_document(f"{digest}  file.exe\n"), digest)
+
+    def test_rejects_bad_hash_document(self):
+        with self.assertRaisesRegex(UpdateError, "SHA-256"):
+            updater.parse_sha256_document("nothex")
+
+    def test_verifies_file_hash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blob"
+            path.write_bytes(b"hello")
+            import hashlib
+
+            expected = hashlib.sha256(b"hello").hexdigest()
+            self.assertEqual(updater.verify_file_sha256(path, expected), expected)
+            with self.assertRaisesRegex(UpdateError, "校验失败"):
+                updater.verify_file_sha256(path, "b" * 64)
+
+
+class HelperTests(unittest.TestCase):
+    def test_launch_update_helper_builds_finalize_command(self):
+        from local_proxy import application
+
+        captured = {}
+
+        def fake_spawn(command, working_directory):
+            captured["command"] = command
+            captured["cwd"] = working_directory
+
+        original = application._spawn_detached
+        application._spawn_detached = fake_spawn
+        try:
+            application.launch_update_helper(Path("/tmp/new/CodexLocalProxy.exe"))
+        finally:
+            application._spawn_detached = original
+        command = captured["command"]
+        self.assertIn("--finalize-update", command)
+        self.assertIn("--target", command)
+        self.assertIn("--wait-pid", command)
+        self.assertEqual(command[0], str(Path("/tmp/new/CodexLocalProxy.exe")))
+
+    def test_process_alive_detects_current_process(self):
+        from local_proxy import application
+
+        self.assertTrue(application._process_alive(os.getpid()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 新增 `local_proxy/updater.py`：查询 GitHub `releases/latest`、semver 比对、按平台选产物、流式下载并做 SHA-256 校验
- 托盘新增「检查更新／更新到 vX.Y.Z」菜单项与通知，启动后后台静默检测一次
- Windows 冻结版全自动闭环：下载校验 → 退出 → 新版二进制以 `--finalize-update` 等待旧进程退出后替换目标文件并重启，失败回滚 `.bak`
- 非 Windows 或源码运行仅检测提示，跳转 Releases 页面手动更新
- README 仓库地址改为实际发布仓库 `AI-Routing-Research-Institute/codex-provider-hub`

## 非目标
- 不做 macOS 就地自更新（依赖后续代码签名与公证），macOS 保持仅检测提示
- 不做增量更新与静默强制升级

## 测试
- `python -m unittest discover -s tests -p "test_*.py"` 全量 410 项通过（含新增 13 项 updater 用例）
- 变更记录：`docs/changes/2026-08-12-windows-online-update.md`