### PR TITLE
feat(proxy): 在线更新入口迁移到 Web 控制台

### DIFF
--- a/docs/changes/2026-08-13-web-update-entry.md
+++ b/docs/changes/2026-08-13-web-update-entry.md
@@ -1,0 +1,55 @@
++++
+id = "2026-08-13-web-update-entry"
+type = "feature"
+release_bump = "minor"
+status = "verified"
++++
+
+# 在线更新入口迁移到 Web 控制台
+
+## 目标
+
+把「检查更新」从仅托盘菜单迁移到 Web 控制台运行设置页：显示当前版本，提供「检查更新」按钮，Windows 便携版额外提供「更新并重启」一键闭环；其他平台仅检测并引导手动下载。
+
+## 现状
+
+在线更新逻辑（`updater.py` + `application.py` 的退出重启闭环）已具备，但入口只在系统托盘菜单里，Web 控制台无任何版本显示或更新入口。
+
+## 设计范围
+
+- `application.py` 新增进程级 `UpdateController`，复用 `updater.check_for_update`/`download_asset` 与 `tray_holder["update_apply_path"]` → `launch_update_helper` 闭环，经 `create_proxy_app(update_controller=...)` 注入。
+- 新增 `GET /api/update`（读缓存状态）、`POST /api/update/check`（线程池检测）、`POST /api/update/apply`（Windows 下载校验后触发退出重启），沿每个 `/control/{service}` 前缀注册。
+- 运行设置页新增「版本与更新」区块：当前版本、检查更新、更新并重启，出错兜底展示 Releases 链接。
+
+## 非目标
+
+不改动检测/下载/校验核心逻辑本身，不做 macOS 就地自更新，不新增 403 限流专项容错（按需求本次仅迁移入口到界面）。
+
+## 实际改动
+
+- `local_proxy/application.py`：新增 `UpdateController`（`status`/`check`/`download`/`finalize`），复用 `updater.check_for_update`、`updater.download_asset`、`updates_directory`、`update_supported`；`run_application` 内构造并经 `create_proxy_app(update_controller=...)` 注入，`finalize` 沿用 `tray_holder["update_apply_path"]` → `launch_update_helper` 退出重启闭环。
+- `local_proxy/core.py`：`create_proxy_app` 新增 `update_controller` 形参并透传给统一应用。
+- `local_proxy/server.py`：`create_unified_proxy_app`/`_register_control_routes` 透传 `update_controller`；新增 `GET /api/update`（读缓存状态）、`POST /api/update/check`（线程池调用检测，`UpdateError` → 502）、`POST /api/update/apply`（下载校验后返回 restarting 并后台触发 finalize），阻塞 httpx 走 `run_in_threadpool`。
+- `proxy_static/index.html`、`proxy_static/app.js`：运行设置页新增「版本与更新」区块，显示当前版本、检查更新、更新并重启，出错时展示信息与 Releases 链接兜底；页面加载时读取版本状态。
+- `tests/test_server.py`：新增 `UpdateRouteTests`（注入 fake controller，覆盖无 controller、检测成功、缺控制头 403、UpdateError → 502、非 Windows 409、下载后触发 finalize）。
+
+## 兼容性
+
+无运行时协议影响。新增均为 `/control/{service}/api/update*` 只读/受控端点，需 `X-Local-Proxy-Control` 头。`update_controller` 缺省为 None 时端点降级为不可用/仅返回版本占位。非 Windows 或源码运行时 `supported=false`，前端隐藏「更新并重启」。
+
+## 风险
+
+- 检测仍走 GitHub 匿名 API（60 次/小时/IP），共享出口 IP 被限流时返回 403，界面展示错误信息 + Releases 手动下载链接兜底，不影响主服务。
+- 一键更新复用既有 Windows 替换闭环，失败回滚 `.bak`。
+
+## 测试计划
+
+`python -m unittest discover -s tests -p "test_*.py"` 全量通过，覆盖新增 update 路由；`node --test` 前端用例回归。
+
+## 验证结果
+
+`python -m unittest discover -s tests -p "test_*.py"` 全量 416 项通过（含新增 6 项 update 路由用例）；`node --test tests/*.test.js` 37 项通过；`node --check proxy_static/app.js` 语法通过。
+
+## PR
+
+pending

--- a/local_proxy/application.py
+++ b/local_proxy/application.py
@@ -11,7 +11,7 @@ import threading
 import time
 import webbrowser
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 # pythonw.exe does not provide standard streams, while Uvicorn initializes
 # logging against them even when access logging is disabled.
@@ -278,6 +278,17 @@ def run_application(
         if icon is not None:
             icon.stop()
 
+    def _on_update_ready(path: Path) -> None:
+        tray_holder["update_apply_path"] = str(path)
+        stop_application()
+
+    update_controller = UpdateController(
+        current_version=APP_VERSION,
+        supported=update_supported(),
+        updates_dir=updates_directory(),
+        on_ready=_on_update_ready,
+    )
+
     codex_profile = build_codex_profile(
         database=database,
         port=port,
@@ -304,6 +315,7 @@ def run_application(
         codex_profile=codex_profile,
         claude_profile=claude_profile,
         on_shutdown_requested=stop_application,
+        update_controller=update_controller,
     )
     server = LocalProxyServer(
         host=DEFAULT_HOST,
@@ -572,6 +584,67 @@ def update_supported() -> bool:
 
 def updates_directory() -> Path:
     return data_directory() / "updates"
+
+
+class UpdateController:
+    def __init__(
+        self,
+        *,
+        current_version: str,
+        supported: bool,
+        updates_dir: Path,
+        on_ready: Callable[[Path], None],
+    ) -> None:
+        self.current_version = current_version
+        self.supported = supported
+        self._updates_dir = updates_dir
+        self._on_ready = on_ready
+        self._lock = threading.Lock()
+        self._last_info: Any = None
+        self._downloaded: Path | None = None
+
+    def status(self) -> dict[str, Any]:
+        from local_proxy.updater import RELEASES_PAGE
+
+        info = self._last_info
+        payload: dict[str, Any] = {
+            "supported": self.supported,
+            "current_version": self.current_version,
+            "has_update": bool(info is not None and info.has_update),
+            "latest_version": info.latest_version if info is not None else None,
+            "release_url": info.release_url if info is not None else RELEASES_PAGE,
+            "notes": info.notes if info is not None else "",
+        }
+        return payload
+
+    def check(self) -> dict[str, Any]:
+        from local_proxy import updater
+
+        info = updater.check_for_update(self.current_version)
+        with self._lock:
+            self._last_info = info
+            self._downloaded = None
+        return self.status()
+
+    def download(self) -> Path:
+        from local_proxy import updater
+
+        with self._lock:
+            info = self._last_info
+        if info is None or not info.has_update:
+            raise updater.UpdateError("请先检查更新")
+        if not self.supported:
+            raise updater.UpdateError("当前平台不支持就地更新")
+        path = updater.download_asset(info, self._updates_dir)
+        with self._lock:
+            self._downloaded = path
+        return path
+
+    def finalize(self) -> None:
+        with self._lock:
+            path = self._downloaded
+        if path is not None:
+            self._on_ready(path)
 
 
 def _spawn_detached(command: list[str], working_directory: Path) -> None:

--- a/local_proxy/core.py
+++ b/local_proxy/core.py
@@ -1926,6 +1926,7 @@ def create_proxy_app(
     config_endpoint_name: str = "codex-config",
     codex_profile: Any | None = None,
     claude_profile: Any | None = None,
+    update_controller: Any | None = None,
 ) -> FastAPI:
     if codex_profile is not None or claude_profile is not None:
         if codex_profile is None or claude_profile is None:
@@ -1937,6 +1938,7 @@ def create_proxy_app(
             claude_profile,
             control_asset_dir=control_asset_dir,
             on_shutdown_requested=on_shutdown_requested,
+            update_controller=update_controller,
         )
     if router is None:
         raise ValueError("必须提供供应商路由器")

--- a/local_proxy/server.py
+++ b/local_proxy/server.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, Mapping
 
 from fastapi import FastAPI, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, RedirectResponse
 from starlette.background import BackgroundTask
@@ -40,6 +41,7 @@ from local_proxy.core import (
     order_proxy_providers,
     retry_policy_from_mapping,
 )
+from local_proxy.updater import RELEASES_PAGE, UpdateError
 
 
 UI_CONFIG_FIELDS = frozenset(
@@ -132,6 +134,7 @@ def create_unified_proxy_app(
     *,
     control_asset_dir: Path = CONTROL_ASSET_DIR,
     on_shutdown_requested: Callable[[], None] | None = None,
+    update_controller: Any | None = None,
 ) -> FastAPI:
     profiles = {"codex": codex, "claude": claude}
 
@@ -196,6 +199,7 @@ def create_unified_proxy_app(
             prefix=f"/control/{service_id}",
             control_asset_dir=control_asset_dir,
             on_shutdown_requested=on_shutdown_requested,
+            update_controller=update_controller,
         )
 
     @app.api_route(
@@ -244,6 +248,7 @@ def _register_control_routes(
     prefix: str,
     control_asset_dir: Path,
     on_shutdown_requested: Callable[[], None] | None,
+    update_controller: Any | None = None,
 ) -> None:
     def public_status(
         window: str = "today",
@@ -655,6 +660,53 @@ def _register_control_routes(
             headers={"Cache-Control": "no-store"},
         )
 
+    async def control_update_status():
+        if update_controller is None:
+            return JSONResponse(
+                content={"supported": False, "current_version": None, "has_update": False},
+                headers={"Cache-Control": "no-store"},
+            )
+        return JSONResponse(
+            content=update_controller.status(),
+            headers={"Cache-Control": "no-store"},
+        )
+
+    async def control_update_check(request: Request):
+        if not _valid_control_request(request):
+            return JSONResponse(status_code=403, content={"detail": "Forbidden"})
+        if update_controller is None:
+            return JSONResponse(status_code=503, content={"detail": "更新功能不可用"})
+        try:
+            status = await run_in_threadpool(update_controller.check)
+        except UpdateError as exc:
+            return JSONResponse(
+                status_code=502,
+                content={"detail": str(exc), "release_url": RELEASES_PAGE},
+            )
+        return JSONResponse(content=status, headers={"Cache-Control": "no-store"})
+
+    async def control_update_apply(request: Request):
+        if not _valid_control_request(request):
+            return JSONResponse(status_code=403, content={"detail": "Forbidden"})
+        if update_controller is None:
+            return JSONResponse(status_code=503, content={"detail": "更新功能不可用"})
+        if not update_controller.supported:
+            return JSONResponse(
+                status_code=409,
+                content={"detail": "当前平台请手动下载安装最新版本", "release_url": RELEASES_PAGE},
+            )
+        try:
+            await run_in_threadpool(update_controller.download)
+        except UpdateError as exc:
+            return JSONResponse(
+                status_code=409,
+                content={"detail": str(exc), "release_url": RELEASES_PAGE},
+            )
+        return JSONResponse(
+            content={"status": "restarting"},
+            background=BackgroundTask(update_controller.finalize),
+        )
+
     async def control_shutdown(request: Request):
         if not _valid_control_request(request):
             return JSONResponse(status_code=403, content={"detail": "Forbidden"})
@@ -715,3 +767,6 @@ def _register_control_routes(
         include_in_schema=False,
     )
     app.add_api_route(f"{prefix}/api/shutdown", control_shutdown, methods=["POST"], include_in_schema=False)
+    app.add_api_route(f"{prefix}/api/update", control_update_status, methods=["GET"], include_in_schema=False)
+    app.add_api_route(f"{prefix}/api/update/check", control_update_check, methods=["POST"], include_in_schema=False)
+    app.add_api_route(f"{prefix}/api/update/apply", control_update_apply, methods=["POST"], include_in_schema=False)

--- a/proxy_static/app.js
+++ b/proxy_static/app.js
@@ -2940,6 +2940,112 @@ async function shutdownProxy() {
   }
 }
 
+let updateState = { supported: false, has_update: false, release_url: "" };
+
+function renderUpdateResult(message, tone) {
+  const box = document.querySelector("#update-result");
+  if (!box) return;
+  if (!message) {
+    box.hidden = true;
+    box.textContent = "";
+    return;
+  }
+  box.hidden = false;
+  box.textContent = "";
+  const span = document.createElement("span");
+  span.textContent = message;
+  box.appendChild(span);
+  if (tone === "update" && updateState.release_url) {
+    const link = document.createElement("a");
+    link.href = updateState.release_url;
+    link.target = "_blank";
+    link.rel = "noreferrer noopener";
+    link.textContent = "打开 Releases 页面";
+    link.style.marginLeft = "8px";
+    box.appendChild(link);
+  }
+}
+
+function applyUpdateState(state) {
+  updateState = { ...updateState, ...state };
+  const versionCode = document.querySelector("#update-current-version");
+  if (versionCode) {
+    versionCode.textContent = state.current_version
+      ? `v${state.current_version}`
+      : "—";
+  }
+  const applyButton = document.querySelector("#update-apply-button");
+  if (applyButton) {
+    applyButton.hidden = !(updateState.has_update && updateState.supported);
+  }
+}
+
+async function loadUpdateStatus() {
+  try {
+    const response = await fetch(controlUrl("/api/update"), { cache: "no-store" });
+    if (!response.ok) return;
+    applyUpdateState(await response.json());
+  } catch (error) {
+    /* 版本信息读取失败时静默降级 */
+  }
+}
+
+async function checkForUpdate() {
+  const button = document.querySelector("#update-check-button");
+  if (button) button.disabled = true;
+  renderUpdateResult("正在检查更新…", "info");
+  try {
+    const response = await fetch(controlUrl("/api/update/check"), {
+      method: "POST",
+      headers: CONTROL_HEADER,
+      cache: "no-store",
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      updateState.release_url = payload.release_url || updateState.release_url;
+      renderUpdateResult(payload.detail || `检查更新失败：HTTP ${response.status}`, "update");
+      return;
+    }
+    applyUpdateState(payload);
+    if (payload.has_update) {
+      renderUpdateResult(`发现新版本 v${payload.latest_version}`, "update");
+    } else {
+      renderUpdateResult("当前已是最新版本。", "info");
+    }
+  } catch (error) {
+    renderUpdateResult(error?.message || "无法连接更新服务。", "info");
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+async function applyUpdate() {
+  const button = document.querySelector("#update-apply-button");
+  if (button) button.disabled = true;
+  renderUpdateResult("正在下载并校验新版本…", "info");
+  try {
+    const response = await fetch(controlUrl("/api/update/apply"), {
+      method: "POST",
+      headers: CONTROL_HEADER,
+      cache: "no-store",
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      updateState.release_url = payload.release_url || updateState.release_url;
+      renderUpdateResult(payload.detail || `更新失败：HTTP ${response.status}`, "update");
+      if (button) button.disabled = false;
+      return;
+    }
+    window.clearInterval(pollTimer);
+    window.clearInterval(healthPollTimer);
+    renderUpdateResult("更新已就绪，正在重启到新版本…", "info");
+    showToast("正在更新", "本地中转会自动重启到新版本。", "success");
+  } catch (error) {
+    renderUpdateResult(error?.message || "无法连接更新服务。", "info");
+    if (button) button.disabled = false;
+  }
+}
+
 searchInput.addEventListener("input", renderProviderList);
 usageWindow.addEventListener("change", () => {
   if (usageWindow.value === "custom") {
@@ -2955,6 +3061,8 @@ healthRefreshButton.addEventListener("click", () => readHealthStatus());
 document.querySelector("#refresh-button").addEventListener("click", refreshProviders);
 document.querySelector("#copy-config").addEventListener("click", copyConfig);
 document.querySelector("#shutdown-button").addEventListener("click", shutdownProxy);
+document.querySelector("#update-check-button").addEventListener("click", checkForUpdate);
+document.querySelector("#update-apply-button").addEventListener("click", applyUpdate);
 for (const button of document.querySelectorAll(".view-tab")) {
   button.addEventListener("click", () => switchView(button.dataset.view));
 }
@@ -3164,6 +3272,7 @@ async function initialize() {
   renderHealthSourceStatus();
   readStatus({ force: true });
   readRuntimeSettings({ quiet: true });
+  loadUpdateStatus();
   pollTimer = window.setInterval(() => readStatus({ quiet: true }), 1000);
   healthPollTimer = window.setInterval(
     () => readHealthStatus({ quiet: true }),

--- a/proxy_static/index.html
+++ b/proxy_static/index.html
@@ -288,6 +288,18 @@
             <button id="save-runtime-settings" class="primary-button" type="submit">保存设置</button>
           </div>
         </form>
+
+        <div id="update-panel" class="settings-form update-panel">
+          <div class="setting-row setting-readonly-row">
+            <span><strong>版本与更新</strong><small id="update-hint">检测最新发布版本</small></span>
+            <div class="setting-control-with-action">
+              <code id="update-current-version">—</code>
+              <button id="update-check-button" class="secondary-button setting-action-button" type="button">检查更新</button>
+              <button id="update-apply-button" class="primary-button setting-action-button" type="button" hidden>更新并重启</button>
+            </div>
+          </div>
+          <div id="update-result" class="setting-notice" hidden></div>
+        </div>
       </section>
 
       <div id="toast-region" class="toast-region" aria-live="polite" aria-atomic="true"></div>

--- a/tests/test_local_proxy_app.py
+++ b/tests/test_local_proxy_app.py
@@ -561,6 +561,7 @@ class CodexConfigTests(unittest.TestCase):
             codex_profile=codex_profile_instance,
             claude_profile=claude_profile_instance,
             on_shutdown_requested=mock.ANY,
+            update_controller=mock.ANY,
         )
         server_class.assert_called_once_with(
             host="127.0.0.1",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -354,5 +354,140 @@ class UnifiedProxyAppTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FakeUpdateController:
+    def __init__(self, *, supported=True, check_error=None, download_error=None):
+        self.supported = supported
+        self._check_error = check_error
+        self._download_error = download_error
+        self.finalized = False
+        self.downloaded = False
+
+    def status(self):
+        return {
+            "supported": self.supported,
+            "current_version": "0.7.1",
+            "has_update": True,
+            "latest_version": "0.8.0",
+            "release_url": "https://example/release",
+            "notes": "",
+        }
+
+    def check(self):
+        if self._check_error is not None:
+            raise self._check_error
+        return self.status()
+
+    def download(self):
+        if self._download_error is not None:
+            raise self._download_error
+        self.downloaded = True
+        return Path("/tmp/new.exe")
+
+    def finalize(self):
+        self.finalized = True
+
+
+class UpdateRouteTests(unittest.IsolatedAsyncioTestCase):
+    def _build(self, controller):
+        codex = ProxyProfile(
+            service_id="codex",
+            service_name="codex-local-proxy",
+            router=ProviderRouter((codex_provider(),)),
+            upstream_client=httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(200))),
+            owns_client=False,
+            config_endpoint_name="codex-config",
+        )
+        claude = ProxyProfile(
+            service_id="claude",
+            service_name="claude-local-proxy",
+            router=ProviderRouter((claude_provider(),)),
+            upstream_client=httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(200))),
+            owns_client=False,
+            protocol_adapter=ClaudeMessagesProtocol(),
+            config_endpoint_name="claude-config",
+        )
+        app = create_proxy_app(
+            codex_profile=codex,
+            claude_profile=claude,
+            update_controller=controller,
+        )
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        )
+
+    async def test_status_returns_version_without_controller(self) -> None:
+        client = self._build(None)
+        try:
+            response = await client.get("/control/codex/api/update")
+        finally:
+            await client.aclose()
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["supported"])
+
+    async def test_check_returns_update_info(self) -> None:
+        client = self._build(FakeUpdateController())
+        try:
+            response = await client.post(
+                "/control/codex/api/update/check",
+                headers={"X-Local-Proxy-Control": "1"},
+            )
+        finally:
+            await client.aclose()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["latest_version"], "0.8.0")
+
+    async def test_check_requires_control_header(self) -> None:
+        client = self._build(FakeUpdateController())
+        try:
+            response = await client.post("/control/codex/api/update/check")
+        finally:
+            await client.aclose()
+        self.assertEqual(response.status_code, 403)
+
+    async def test_check_maps_update_error_to_502(self) -> None:
+        from local_proxy.updater import UpdateError
+
+        client = self._build(FakeUpdateController(check_error=UpdateError("检查更新失败：HTTP 403")))
+        try:
+            response = await client.post(
+                "/control/codex/api/update/check",
+                headers={"X-Local-Proxy-Control": "1"},
+            )
+        finally:
+            await client.aclose()
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("403", response.json()["detail"])
+        self.assertIn("release_url", response.json())
+
+    async def test_apply_rejects_unsupported_platform(self) -> None:
+        controller = FakeUpdateController(supported=False)
+        client = self._build(controller)
+        try:
+            response = await client.post(
+                "/control/codex/api/update/apply",
+                headers={"X-Local-Proxy-Control": "1"},
+            )
+        finally:
+            await client.aclose()
+        self.assertEqual(response.status_code, 409)
+        self.assertFalse(controller.finalized)
+
+    async def test_apply_downloads_then_schedules_finalize(self) -> None:
+        controller = FakeUpdateController()
+        client = self._build(controller)
+        try:
+            response = await client.post(
+                "/control/codex/api/update/apply",
+                headers={"X-Local-Proxy-Control": "1"},
+            )
+        finally:
+            await client.aclose()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "restarting")
+        self.assertTrue(controller.downloaded)
+        self.assertTrue(controller.finalized)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要
- `application.py` 新增进程级 `UpdateController`（status/check/download/finalize），复用 `updater` 与既有 Windows 退出重启闭环，经 `create_proxy_app(update_controller=...)` 注入
- `core.py`、`server.py` 透传 `update_controller`；新增 `GET /api/update`、`POST /api/update/check`（`UpdateError`→502）、`POST /api/update/apply`（下载校验后 restarting + 后台 finalize），阻塞 httpx 走 `run_in_threadpool`
- 运行设置页新增「版本与更新」区块：显示当前版本、检查更新、更新并重启，出错展示信息与 Releases 链接兜底

## 说明
- 「检查更新」出现 403 属 GitHub 匿名 API 限流（60 次/小时/IP，公司共享出口 IP 易被打满），本次按需求仅迁移入口到界面，未加 403 专项容错，界面会展示错误 + Releases 手动下载链接兜底
- 非 Windows 或源码运行 `supported=false`，前端隐藏「更新并重启」

## 测试
- `python -m unittest discover -s tests -p "test_*.py"` 全量 416 项通过（含新增 6 项 update 路由用例）
- `node --test tests/*.test.js` 37 项通过；`node --check proxy_static/app.js` 语法通过
- 变更记录：`docs/changes/2026-08-13-web-update-entry.md`