### PR TITLE
🐞 fix(status): 隔离供应商 DNS 启动故障

### DIFF
--- a/docs/changes/2026-08-13-transient-provider-dns.md
+++ b/docs/changes/2026-08-13-transient-provider-dns.md
@@ -64,4 +64,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/28

--- a/docs/changes/2026-08-13-transient-provider-dns.md
+++ b/docs/changes/2026-08-13-transient-provider-dns.md
@@ -1,0 +1,67 @@
++++
+id = "2026-08-13-transient-provider-dns"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 容忍供应商域名临时解析失败
+
+## 目标
+
+单个供应商域名临时无法解析或已经失效时，状态探测 worker 仍可启动并继续检测其他供应商；失效供应商在实际检测时记录独立失败。
+
+## 现状
+
+`load_config()` 会在 worker 启动时解析所有供应商域名。任一域名返回 NXDOMAIN 或发生临时 DNS 错误时，整个配置加载失败，worker 进入重启循环。2026-08-13 部署重启时，`welfare.0xpsyche.me` 已被公共 DNS 确认为 NXDOMAIN，因此其余供应商也无法继续自动检测。
+
+## 设计范围
+
+- 配置加载继续验证 HTTPS URL 结构、禁止凭据/查询参数/片段、localhost 和非公网 IP 字面量。
+- 配置加载时若域名能够解析，继续拒绝任何非公网解析结果。
+- 配置加载时仅容忍域名当前无记录或解析器临时失败，不因单个供应商阻止 worker 启动。
+- 每次自动检测和点击检测前重新严格解析本次客户端实际使用的端点。
+- 运行时无法解析或解析到非公网地址时，不启动 Codex/Claude 客户端，并返回该供应商的检测失败结果。
+- 增加配置加载、自动检测与点击检测共用探测路由的回归测试。
+
+## 非目标
+
+- 不修改供应商地址、凭据、检测周期或状态页排序。
+- 不绕过 HTTP、localhost、私网、链路本地地址或 DNS 重绑定防护。
+- 不在服务器 hosts 文件中固定供应商地址，也不创建占位凭据。
+
+## 兼容性
+
+无接口、配置格式或数据库迁移。仅把启动阶段的 DNS 可用性要求延后到每次实际检测，选择 `patch`，因为这是 worker 可用性的缺陷修复。
+
+## 风险
+
+域名失效的供应商会持续产生独立网络失败记录；通过现有失败退避降低请求频率。运行时严格公网解析在每次检测前执行，确保启动容忍不会放宽实际请求的网络边界。
+
+## 测试计划
+
+- 测试配置加载允许解析器抛出临时错误和返回空地址。
+- 测试配置加载仍拒绝私网解析结果及所有既有非法 URL。
+- 测试运行时 DNS 失败和私网解析时不调用底层探测客户端。
+- 测试运行时公网解析后正常调用对应 Codex/Claude 客户端。
+- 运行状态模块聚焦测试、Python 与 JavaScript 全量测试、语法、编译和 diff 检查。
+
+## 实际改动
+
+- `provider_status/config.py`：复用公开 HTTPS 端点校验；配置加载仅容忍 DNS 异常或空解析，仍拒绝非法 URL 和已解析出的非公网地址。
+- `provider_status/probe.py`：自动与点击检测共用的路由在每次调用底层 Codex/Claude 客户端前严格校验对应端点；失败时返回 `network_error`，不启动客户端。
+- `tests/test_status_config.py`：覆盖启动阶段 DNS 异常和空解析容忍，并保留私网解析拒绝回归。
+- `tests/test_claude_probe.py`：覆盖运行时公网路由、DNS 失败和私网解析拦截。
+
+## 验证结果
+
+- `.venv\Scripts\python.exe -m unittest tests.test_status_config tests.test_status_probe tests.test_claude_probe -v`：49 项通过。
+- `.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"`：432 项通过。
+- 对 `tests/*.test.js` 执行 `node --test`：40 项通过。
+- `node --check proxy_static/app.js` 与 `node --check provider_status/static/app.js`：通过。
+- `.venv\Scripts\python.exe -m compileall -q provider_status local_proxy scripts`：通过。
+- `git diff --check`：通过。
+
+## PR
+
+pending

--- a/provider_status/config.py
+++ b/provider_status/config.py
@@ -113,7 +113,12 @@ def load_config(
         provider_ids.add(provider_id)
 
         base_url = _required_string(raw_provider, "base_url", provider_id)
-        _validate_public_https_endpoint(base_url, provider_id, active_resolver)
+        validate_public_https_endpoint(
+            base_url,
+            provider_id,
+            active_resolver,
+            allow_resolution_failure=True,
+        )
         healthy_interval_seconds = _positive_number(
             raw_provider,
             "healthy_interval_seconds",
@@ -128,11 +133,12 @@ def load_config(
         model_clients = _model_clients(raw_provider, provider_id, models)
         claude_base_url = _optional_string(raw_provider, "claude_base_url")
         if claude_base_url is not None:
-            _validate_public_https_endpoint(
+            validate_public_https_endpoint(
                 claude_base_url,
                 provider_id,
                 active_resolver,
                 field_name="claude_base_url",
+                allow_resolution_failure=True,
             )
         if (
             any(client == PROBE_CLIENT_CLAUDE for _, client in model_clients)
@@ -402,12 +408,13 @@ def _timeout_seconds(
     return value
 
 
-def _validate_public_https_endpoint(
+def validate_public_https_endpoint(
     base_url: str,
     provider_id: str,
     resolver: Resolver,
     *,
     field_name: str = "base_url",
+    allow_resolution_failure: bool = False,
 ) -> None:
     error_prefix = (
         f"provider {provider_id!r} {field_name} must be a public HTTPS endpoint"
@@ -444,10 +451,18 @@ def _validate_public_https_endpoint(
     try:
         answers = resolver(hostname, port, type=socket.SOCK_STREAM)
         addresses = tuple(_resolved_addresses(answers))
-    except (OSError, TypeError, ValueError) as exc:
+    except OSError as exc:
+        if allow_resolution_failure:
+            return
         raise ValueError(f"{error_prefix}: hostname resolution failed") from exc
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{error_prefix}: invalid hostname resolution result") from exc
 
-    if not addresses or any(not address.is_global for address in addresses):
+    if not addresses:
+        if allow_resolution_failure:
+            return
+        raise ValueError(f"{error_prefix}: hostname resolution returned no addresses")
+    if any(not address.is_global for address in addresses):
         raise ValueError(error_prefix)
 
 

--- a/provider_status/probe.py
+++ b/provider_status/probe.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import stat
 import tempfile
 import time
@@ -19,6 +20,8 @@ from provider_status.config import (
     PROBE_CLIENT_CLAUDE,
     PROBE_CLIENT_CODEX,
     ProviderConfig,
+    Resolver,
+    validate_public_https_endpoint,
 )
 from provider_status.store import sanitize_error_summary
 from provider_status.tui_probe import (
@@ -71,9 +74,12 @@ class ProviderHealthProbe:
         self,
         codex_probe: Any,
         claude_probe: Any | None = None,
+        *,
+        resolver: Resolver = socket.getaddrinfo,
     ) -> None:
         self._codex_probe = codex_probe
         self._claude_probe = claude_probe
+        self._resolver = resolver
 
     def run(
         self,
@@ -82,6 +88,32 @@ class ProviderHealthProbe:
         api_key: str,
     ) -> HealthProbeResult:
         client = provider.probe_client(model)
+        endpoint = (
+            provider.claude_base_url
+            if client == PROBE_CLIENT_CLAUDE
+            else provider.base_url
+        )
+        if endpoint:
+            try:
+                validate_public_https_endpoint(
+                    endpoint,
+                    provider.provider_id,
+                    self._resolver,
+                    field_name=(
+                        "claude_base_url"
+                        if client == PROBE_CLIENT_CLAUDE
+                        else "base_url"
+                    ),
+                )
+            except ValueError as exc:
+                return HealthProbeResult(
+                    success=False,
+                    latency_ms=0,
+                    error_code="network_error",
+                    error_summary=str(exc),
+                    failure_stage="probe_setup",
+                    diagnostic_source="probe_router",
+                )
         if client == PROBE_CLIENT_CODEX:
             return self._codex_probe.run(provider, model, api_key)
         if client == PROBE_CLIENT_CLAUDE and self._claude_probe is not None:

--- a/tests/test_claude_probe.py
+++ b/tests/test_claude_probe.py
@@ -243,7 +243,11 @@ class ClaudeHealthProbeTests(unittest.TestCase):
 
         codex = FakeProbe("codex")
         claude = FakeProbe("claude")
-        router = ProviderHealthProbe(codex, claude)
+        router = ProviderHealthProbe(
+            codex,
+            claude,
+            resolver=lambda *args, **kwargs: ["8.8.8.8"],
+        )
 
         self.assertEqual(router.run(make_provider(), "gpt-5.6-sol", API_KEY), "codex")
         self.assertEqual(
@@ -252,6 +256,51 @@ class ClaudeHealthProbeTests(unittest.TestCase):
         )
         self.assertEqual(codex.calls, ["gpt-5.6-sol"])
         self.assertEqual(claude.calls, ["claude-opus-5"])
+
+    def test_provider_router_blocks_unresolved_endpoint_before_client(self) -> None:
+        class FakeProbe:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def run(self, provider, model, api_key):
+                del provider, model, api_key
+                self.calls += 1
+                raise AssertionError("client must not run for an unresolved endpoint")
+
+        def unavailable_resolver(*args, **kwargs):
+            del args, kwargs
+            raise OSError("name resolution failed")
+
+        codex = FakeProbe()
+        claude = FakeProbe()
+        router = ProviderHealthProbe(codex, claude, resolver=unavailable_resolver)
+
+        result = router.run(make_provider(), "gpt-5.6-sol", API_KEY)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, "network_error")
+        self.assertEqual(result.failure_stage, "probe_setup")
+        self.assertEqual(result.diagnostic_source, "probe_router")
+        self.assertEqual(codex.calls, 0)
+        self.assertEqual(claude.calls, 0)
+
+    def test_provider_router_blocks_private_dns_answer_before_client(self) -> None:
+        class FakeProbe:
+            def run(self, provider, model, api_key):
+                del provider, model, api_key
+                raise AssertionError("client must not run for a private endpoint")
+
+        router = ProviderHealthProbe(
+            FakeProbe(),
+            FakeProbe(),
+            resolver=lambda *args, **kwargs: ["127.0.0.1"],
+        )
+
+        result = router.run(make_provider(), "claude-opus-5", API_KEY)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, "network_error")
+        self.assertIn("public HTTPS endpoint", result.error_summary)
 
 
 class ClaudeProcessTests(unittest.TestCase):

--- a/tests/test_status_config.py
+++ b/tests/test_status_config.py
@@ -319,6 +319,28 @@ class StatusConfigTests(unittest.TestCase):
                 resolver=rebinding_resolver,
             )
 
+    def test_allows_temporary_dns_resolution_failure_at_startup(self) -> None:
+        def unavailable_resolver(
+            host: str, port: int, *args: object, **kwargs: object
+        ) -> list[tuple]:
+            del host, port, args, kwargs
+            raise socket.gaierror(socket.EAI_NONAME, "name not known")
+
+        config = self.load_text(
+            service_config(provider_block()),
+            resolver=unavailable_resolver,
+        )
+
+        self.assertEqual(config.providers[0].provider_id, "provider-alpha")
+
+    def test_allows_empty_dns_answer_at_startup(self) -> None:
+        config = self.load_text(
+            service_config(provider_block()),
+            resolver=lambda *args, **kwargs: [],
+        )
+
+        self.assertEqual(config.providers[0].base_url, "https://alpha.example.com/v1")
+
     def test_rejects_duplicate_provider_id(self) -> None:
         text = service_config(
             provider_block(),


### PR DESCRIPTION
## 功能说明
- 单个供应商域名临时无法解析时，不再阻断整个状态 worker 启动。
- 配置加载仍拒绝非法 HTTPS URL、localhost、私网 IP 和已解析出的私网地址。
- 自动与点击检测每次调用底层客户端前严格重新解析端点；DNS 失败或私网结果只记录该供应商 `network_error`。

## 线上触发原因
- `welfare.0xpsyche.me` 当前被 1.1.1.1 与 8.8.8.8 确认为 NXDOMAIN，部署重启暴露了启动阶段全局失败问题。

## 风险与兼容性
- 不修改配置格式、数据库、状态页接口或供应商地址。
- 运行时检查保持 SSRF 边界；异常端点不会启动 Codex/Claude 客户端。

## 验证
- 聚焦状态配置/探测测试：49 项通过。
- Python 全量：432 项通过。
- JavaScript：40 项通过。
- JavaScript 语法、Python compileall、diff 检查：通过。
- Ruleset `agent-delivery-main`（ID 20543407）：验证通过。

## 变更记录
- `docs/changes/2026-08-13-transient-provider-dns.md`