### PR TITLE
🐞 fix(proxy): 避免请求持久化阻塞本地中转

### DIFF
--- a/docs/changes/2026-08-14-nonblocking-request-persistence.md
+++ b/docs/changes/2026-08-14-nonblocking-request-persistence.md
@@ -73,4 +73,4 @@ HTTP 接口、配置和 SQLite 表结构保持不变，无需数据迁移。历�
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/31

--- a/docs/changes/2026-08-14-nonblocking-request-persistence.md
+++ b/docs/changes/2026-08-14-nonblocking-request-persistence.md
@@ -1,0 +1,76 @@
++++
+id = "2026-08-14-nonblocking-request-persistence"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 本地中转请求持久化阻塞修复
+
+## 目标
+
+消除请求历史读取与请求结束落库之间的锁竞争对 ASGI 事件循环的阻塞，确保数据库繁忙或历史查询较慢时，正常中转请求、健康接口和控制接口仍能继续推进。
+
+## 现状
+
+请求历史接口虽然已将同步查询移到工作线程，但 `UsageStore.request_history()` 会在持有共享锁期间先执行过期记录删除，再查询历史。正常中转请求结束时仍在 ASGI 事件循环线程同步写入用量和请求记录；当历史查询线程持有共享锁并等待 SQLite 写锁时，请求结束落库会在事件循环中等待同一把锁，进而暂停整个本地代理。此时不仅请求历史接口卡住，新的 `/v1` 中转请求也无法发往上游，用户只能手动重启进程恢复。
+
+初版异步持久化将 Token 和请求历史拆成两个连续的 `asyncio.to_thread()` 调用。客户端断开检测在第一个调用期间取消流任务时，Token 写线程仍会完成，但第二个请求历史调用不会启动，产生无法关联会话、耗时和推理强度的孤立 Token 记录。现场数据库在 09:56 重启加载初版修改后初查已有 48 条此类记录；旧进程继续运行后增长到 125 条，时间范围为 09:58:39 至 12:42:03。页面将它们按兼容旧记录显示为“未知会话”。
+
+## 设计范围
+
+- 将请求历史保留期清理改为节流执行，普通历史读取不再每次启动删除写事务。
+- 将中转请求结束阶段的用量、请求和恢复记录持久化移出 ASGI 事件循环线程。
+- 将单次流请求的恢复、Token 和请求历史写入合并到同一个线程任务，避免流任务取消造成半写入。
+- 保证路由请求状态的释放不依赖数据库写入及时完成，数据库记录失败不阻止代理继续处理请求。
+- 增加确定性并发回归测试，覆盖历史查询占用持久化锁时正常中转和健康接口仍可推进。
+- 增加清理节流测试，验证连续历史读取不会重复执行过期数据删除。
+
+## 非目标
+
+- 不改变上游供应商选择、重试、会话绑定或模型切换逻辑。
+- 不改变请求历史接口字段、分页、筛选语义和保留期限。
+- 不重构 SQLite 数据结构，不修改用户现有供应商或运行配置。
+- 不在交付后自动重启用户当前运行的本地代理进程。
+
+## 兼容性
+
+HTTP 接口、配置和 SQLite 表结构保持不变，无需数据迁移。历史记录仍按现有保留期限清理，仅降低清理频率。该改动为向后兼容的运行时阻塞修复，因此发布版本选择 `patch`。
+
+## 风险
+
+异步持久化可能改变请求结束时内部操作顺序；通过先释放路由状态、在线程中完成数据库操作并保持单次记录内容不变来降低风险。节流清理会让刚超过保留期限的记录最多延迟一个清理周期删除，但查询时间窗口仍会排除这些记录，不影响接口结果。并发测试使用可控事件和超时，避免依赖机器时序。
+
+## 测试计划
+
+- 新增测试模拟请求历史线程持有持久化锁，验证流式请求结束不会阻塞事件循环和后续中转。
+- 验证数据库持久化完成后用量、请求历史和恢复记录内容不变。
+- 验证请求历史清理按周期触发，连续读取不重复开启删除事务。
+- 运行相关 Python 单元测试、完整 Python 测试、Node 测试、JavaScript 语法检查、Python 编译检查和 `git diff --check`。
+
+## 实际改动
+
+- `local_proxy/core.py` 为请求历史清理增加一小时节流；请求写入和历史读取共享清理状态，普通查询不再每次执行 `DELETE` 写事务。
+- `local_proxy/core.py` 将用量、请求和恢复事件持久化统一移到 `asyncio.to_thread()`，并在数据库持久化前关闭上游响应、释放路由请求状态。
+- `local_proxy/core.py` 将流请求的恢复记录、Token 和请求历史组成一个连续后台任务；任务启动后即使外层流被取消，也会完成 `usage_id` 关联写入。
+- `local_proxy/core.py` 和 `local_proxy/server.py` 将会话路由回查中的 UsageStore 与会话键解析移到工作线程，避免控制操作重新引入同类事件循环阻塞。
+- `tests/test_proxy_core.py` 增加锁竞争回归测试，验证历史查询占锁且首个请求等待持久化时，第二个正常中转仍会到达上游；增加请求历史清理节流测试和流任务取消期间 Token/请求历史完整关联测试。
+
+## 验证结果
+
+- `.\.venv\Scripts\python.exe -m unittest tests.test_proxy_core.UsageTests.test_request_history_cleanup_is_throttled tests.test_proxy_core.ProxyAppTests.test_persistence_lock_does_not_block_following_upstream_request tests.test_proxy_core.ProxyAppTests.test_stream_usage_is_persisted_for_final_provider tests.test_proxy_core.ProxyAppTests.test_request_api_hides_thread_id_and_persists_session_route`：4 项通过。
+- `.\.venv\Scripts\python.exe -m unittest tests.test_proxy_core.ProxyAppTests.test_cancelled_persistence_keeps_usage_and_request_history_linked`：旧实现按预期失败，修复后通过。
+- `.\.venv\Scripts\python.exe -m unittest tests.test_proxy_core.UsageTests tests.test_proxy_core.RecoveryHistoryTests tests.test_proxy_core.ProxyAppTests tests.test_server`：91 项通过。
+- `.\.venv\Scripts\python.exe -m unittest discover -s tests -p 'test_*.py'`：435 项通过。
+- `node --test tests\*.test.js`：40 项通过。
+- `node --check proxy_static\app.js`：通过。
+- `.\.venv\Scripts\python.exe -m compileall -q local_proxy tests`：通过。
+- `.\.venv\Scripts\python.exe scripts\team_policy.py pre-commit`：通过。
+- `git diff --check`：通过，仅输出工作区既有的 LF/CRLF 转换提示。
+- `.\.venv\Scripts\python.exe scripts\team_policy.py verify-ruleset --repo loongkkk/codex-provider-hub`：通过，规则集 `agent-delivery-main`（ID `20543407`）验证成功。
+- 功能分支已 rebase 到 `origin/main` 的 `398bf87`，并针对 rebased HEAD 重新运行上述完整 Python、Node、语法、编译和门禁验证，结果全部通过。
+- 尚未重启当前本地代理进行真实运行验证；本次仅允许本地提交，等待手动重启测试后再进入 push 和 PR 交付流程。
+
+## PR
+
+pending

--- a/local_proxy/core.py
+++ b/local_proxy/core.py
@@ -46,6 +46,7 @@ RECOVERY_HISTORY_API_LIMIT = 500
 RECOVERY_HISTORY_CLEANUP_INTERVAL_SECONDS = 3600
 USAGE_HISTORY_PAGE_LIMIT = 50
 REQUEST_HISTORY_HOURS = 7 * 24
+REQUEST_HISTORY_CLEANUP_INTERVAL_SECONDS = 3600
 REQUEST_HISTORY_PAGE_LIMIT = 50
 REQUEST_HISTORY_WINDOWS = {"1h", "6h", "24h", "7d", "custom"}
 SSE_RETRY_EVENT_PARSE_BYTES = 256 * 1024
@@ -172,6 +173,7 @@ class UsageStore:
     def __init__(self, path: Path) -> None:
         self.path = path
         self._lock = threading.Lock()
+        self._last_request_history_cleanup_at = 0.0
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
@@ -369,10 +371,7 @@ class UsageStore:
                 """,
                 values,
             )
-            connection.execute(
-                "DELETE FROM request_history WHERE finished_at < ?",
-                (completed_at - REQUEST_HISTORY_HOURS * 3600,),
-            )
+            self._cleanup_request_history_if_due(connection, completed_at)
 
     def request_history(
         self,
@@ -472,11 +471,9 @@ class UsageStore:
         count_params = params[:-3] if cursor else params
         with self._lock, closing(self._connect()) as connection:
             connection.row_factory = sqlite3.Row
-            with connection:
-                connection.execute(
-                    "DELETE FROM request_history WHERE finished_at < ?",
-                    (timestamp - REQUEST_HISTORY_HOURS * 3600,),
-                )
+            if self._request_history_cleanup_due(timestamp):
+                with connection:
+                    self._delete_expired_request_history(connection, timestamp)
             total_count = int(
                 connection.execute(
                     f"{common_table} SELECT COUNT(*) FROM items WHERE {' AND '.join(count_clauses)}",
@@ -538,6 +535,32 @@ class UsageStore:
                 else f"{float(last_row['sort_at']).hex()}@{int(last_row['cursor_id'])}"
             ),
         }
+
+    def _request_history_cleanup_due(self, now: float) -> bool:
+        return (
+            now < self._last_request_history_cleanup_at
+            or now - self._last_request_history_cleanup_at
+            >= REQUEST_HISTORY_CLEANUP_INTERVAL_SECONDS
+        )
+
+    def _cleanup_request_history_if_due(
+        self,
+        connection: sqlite3.Connection,
+        now: float,
+    ) -> None:
+        if self._request_history_cleanup_due(now):
+            self._delete_expired_request_history(connection, now)
+
+    def _delete_expired_request_history(
+        self,
+        connection: sqlite3.Connection,
+        now: float,
+    ) -> None:
+        connection.execute(
+            "DELETE FROM request_history WHERE finished_at < ?",
+            (now - REQUEST_HISTORY_HOURS * 3600,),
+        )
+        self._last_request_history_cleanup_at = now
 
     def thread_id_for_session_key(self, session_key: str) -> str | None:
         with self._lock, closing(self._connect()) as connection:
@@ -2269,9 +2292,12 @@ def create_proxy_app(
             return JSONResponse(status_code=422, content={"detail": "provider_id 必须是字符串或 null"})
         thread_id = router.thread_id_for_session_key(session_key)
         if thread_id is None:
-            thread_id = usage_store.thread_id_for_session_key(session_key)
+            thread_id = await asyncio.to_thread(
+                usage_store.thread_id_for_session_key,
+                session_key,
+            )
         if thread_id is None and session_key_resolver is not None:
-            thread_id = session_key_resolver(session_key)
+            thread_id = await asyncio.to_thread(session_key_resolver, session_key)
         if thread_id is None:
             return JSONResponse(status_code=404, content={"detail": "未找到该会话"})
         if provider_id is not None:
@@ -2969,6 +2995,102 @@ def _record_request_event(
         pass
 
 
+async def _record_recovery_event_async(
+    store: RecoveryHistoryStore | None,
+    **event: Any,
+) -> None:
+    if store is None:
+        return
+    await asyncio.to_thread(_record_recovery_event, store, **event)
+
+
+async def _record_request_event_async(
+    store: UsageStore | None,
+    **event: Any,
+) -> None:
+    if store is None:
+        return
+    await asyncio.to_thread(_record_request_event, store, **event)
+
+
+def _record_stream_completion(
+    usage_store: UsageStore | None,
+    recovery_history_store: RecoveryHistoryStore | None,
+    *,
+    snapshot: RouteSnapshot,
+    thread_id: str | None,
+    session_name_resolver: Callable[[Iterable[str]], Mapping[str, str]] | None,
+    model: str,
+    reasoning_effort: str | None,
+    usage: TokenUsage | None,
+    status_code: int,
+    successful: bool,
+    retry_count: int,
+    error_kind: str | None,
+    error_summary: str | None,
+    stream_failure: tuple[str, str] | None,
+    attempt: int,
+    max_attempts: int,
+) -> None:
+    if stream_failure is not None:
+        kind, summary = stream_failure
+        _record_recovery_event(
+            recovery_history_store,
+            snapshot=snapshot,
+            provider_id=snapshot.provider.provider_id,
+            attempt=attempt,
+            max_attempts=max_attempts,
+            delay_seconds=None,
+            kind=kind,
+            summary=summary,
+            stage="after_output",
+            outcome="passed_through",
+        )
+    usage_id: int | None = None
+    if usage_store is not None and usage is not None:
+        try:
+            usage_id = usage_store.record(
+                provider_id=snapshot.provider.provider_id,
+                model=model,
+                usage=usage,
+                status_code=status_code,
+                successful=successful,
+            )
+        except (OSError, sqlite3.Error):
+            pass
+    _record_request_event(
+        usage_store,
+        snapshot=snapshot,
+        thread_id=thread_id,
+        session_name_resolver=session_name_resolver,
+        model=model,
+        reasoning_effort=reasoning_effort,
+        status_code=status_code,
+        successful=successful,
+        outcome="succeeded" if successful else "failed",
+        retry_count=retry_count,
+        error_kind=error_kind,
+        error_summary=error_summary,
+        usage=usage,
+        usage_id=usage_id,
+    )
+
+
+async def _record_stream_completion_async(
+    usage_store: UsageStore | None,
+    recovery_history_store: RecoveryHistoryStore | None,
+    **event: Any,
+) -> None:
+    if usage_store is None and recovery_history_store is None:
+        return
+    await asyncio.to_thread(
+        _record_stream_completion,
+        usage_store,
+        recovery_history_store,
+        **event,
+    )
+
+
 async def _forward_request(
     router: ProviderRouter,
     client: httpx.AsyncClient,
@@ -2998,7 +3120,8 @@ async def _forward_request(
         )
     provider = snapshot.provider
     if not provider.has_credentials:
-        _record_request_event(
+        router.finish_request(snapshot, status_code=503, error="credential_missing")
+        await _record_request_event_async(
             usage_store,
             snapshot=snapshot,
             thread_id=thread_id,
@@ -3011,14 +3134,14 @@ async def _forward_request(
             error_kind="credential_missing",
             error_summary="当前供应商没有可用认证配置",
         )
-        router.finish_request(snapshot, status_code=503, error="credential_missing")
         return JSONResponse(
             status_code=503,
             content={"error": {"message": "当前供应商没有可用认证配置"}},
         )
 
     if _would_proxy_to_itself(provider, request):
-        _record_request_event(
+        router.finish_request(snapshot, status_code=508, error="proxy_loop")
+        await _record_request_event_async(
             usage_store,
             snapshot=snapshot,
             thread_id=thread_id,
@@ -3031,7 +3154,6 @@ async def _forward_request(
             error_kind="proxy_loop",
             error_summary="当前供应商地址指向本地中转自身",
         )
-        router.finish_request(snapshot, status_code=508, error="proxy_loop")
         return JSONResponse(
             status_code=508,
             content={"error": {"message": "当前供应商地址指向本地中转自身"}},
@@ -3040,7 +3162,8 @@ async def _forward_request(
     try:
         request_body = await _read_request_body(request)
     except ValueError:
-        _record_request_event(
+        router.finish_request(snapshot, status_code=413, error="request_too_large")
+        await _record_request_event_async(
             usage_store,
             snapshot=snapshot,
             thread_id=thread_id,
@@ -3053,7 +3176,6 @@ async def _forward_request(
             error_kind="request_too_large",
             error_summary="请求体超过本地中转允许的大小",
         )
-        router.finish_request(snapshot, status_code=413, error="request_too_large")
         return JSONResponse(
             status_code=413,
             content={"error": {"message": "请求体超过本地中转允许的大小"}},
@@ -3234,7 +3356,7 @@ async def _forward_request(
             upstream_response = None
         if not can_retry:
             if retry_kind is not None:
-                _record_recovery_event(
+                await _record_recovery_event_async(
                     recovery_history_store,
                     snapshot=snapshot,
                     provider_id=snapshot.provider.provider_id,
@@ -3264,7 +3386,7 @@ async def _forward_request(
             error_summary=retry_summary,
             error_provider_id=failed_provider_id,
         )
-        _record_recovery_event(
+        await _record_recovery_event_async(
             recovery_history_store,
             snapshot=snapshot,
             provider_id=failed_provider_id,
@@ -3281,7 +3403,8 @@ async def _forward_request(
 
     if upstream_response is None or stream is None:
         router.record_outcome(snapshot, transient_failure=True, policy=retry_policy)
-        _record_request_event(
+        router.finish_request(snapshot, status_code=502, error=final_error)
+        await _record_request_event_async(
             usage_store,
             snapshot=snapshot,
             thread_id=thread_id,
@@ -3295,7 +3418,6 @@ async def _forward_request(
             error_kind=final_error,
             error_summary=final_summary or _retry_kind_summary(final_error),
         )
-        router.finish_request(snapshot, status_code=502, error=final_error)
         return JSONResponse(
             status_code=502,
             content={"error": {"message": "当前供应商临时不可用，自动重试后仍未恢复"}},
@@ -3335,6 +3457,8 @@ async def _forward_request(
         stream_failure: tuple[str, str] | None = None
         stream_completed = False
         history_kind: str | None = None
+        history_summary: str | None = None
+        persistence_ready = False
         try:
             if first_chunk is not None:
                 if usage_capture is not None:
@@ -3357,47 +3481,14 @@ async def _forward_request(
             )
             raise
         finally:
+            usage: TokenUsage | None = None
             try:
                 if failure_capture is not None:
                     embedded_failure = failure_capture.finalize()
                     if embedded_failure is not None:
                         stream_failure = embedded_failure
-                if stream_failure is not None:
-                    kind, summary = stream_failure
-                    _record_recovery_event(
-                        recovery_history_store,
-                        snapshot=snapshot,
-                        provider_id=snapshot.provider.provider_id,
-                        attempt=attempt,
-                        max_attempts=retry_policy.max_attempts,
-                        delay_seconds=None,
-                        kind=kind,
-                        summary=summary,
-                        stage="after_output",
-                        outcome="passed_through",
-                    )
-                usage: TokenUsage | None = None
-                usage_id: int | None = None
                 if usage_capture is not None and usage_store is not None:
                     usage = usage_capture.finalize(upstream_response.status_code)
-                    terminal_success = bool(
-                        getattr(usage_capture, "saw_successful_terminal_event", False)
-                    )
-                    if usage is not None:
-                        try:
-                            usage_id = usage_store.record(
-                                provider_id=snapshot.provider.provider_id,
-                                model=usage_capture.model,
-                                usage=usage,
-                                status_code=upstream_response.status_code,
-                                successful=(
-                                    (stream_completed or terminal_success)
-                                    and stream_failure is None
-                                    and 200 <= upstream_response.status_code < 300
-                                ),
-                            )
-                        except (OSError, sqlite3.Error):
-                            pass
                 successful = (
                     (
                         stream_completed
@@ -3421,22 +3512,7 @@ async def _forward_request(
                     else:
                         history_kind = f"http_{upstream_response.status_code}"
                         history_summary = f"HTTP {upstream_response.status_code}"
-                _record_request_event(
-                    usage_store,
-                    snapshot=snapshot,
-                    thread_id=thread_id,
-                    session_name_resolver=session_name_resolver,
-                    model=usage_capture.model if usage_capture is not None else model,
-                    reasoning_effort=reasoning_effort,
-                    status_code=upstream_response.status_code,
-                    successful=successful,
-                    outcome="succeeded" if successful else "failed",
-                    retry_count=max(0, attempt - 1),
-                    error_kind=history_kind,
-                    error_summary=history_summary,
-                    usage=usage,
-                    usage_id=usage_id,
-                )
+                persistence_ready = True
             finally:
                 try:
                     await upstream_response.aclose()
@@ -3446,6 +3522,29 @@ async def _forward_request(
                         status_code=upstream_response.status_code,
                         error=history_kind,
                     )
+                    if persistence_ready:
+                        await _record_stream_completion_async(
+                            usage_store,
+                            recovery_history_store,
+                            snapshot=snapshot,
+                            thread_id=thread_id,
+                            session_name_resolver=session_name_resolver,
+                            model=(
+                                usage_capture.model
+                                if usage_capture is not None
+                                else model
+                            ),
+                            reasoning_effort=reasoning_effort,
+                            usage=usage,
+                            status_code=upstream_response.status_code,
+                            successful=successful,
+                            retry_count=max(0, attempt - 1),
+                            error_kind=history_kind,
+                            error_summary=history_summary,
+                            stream_failure=stream_failure,
+                            attempt=attempt,
+                            max_attempts=retry_policy.max_attempts,
+                        )
 
     return DisconnectAwareStreamingResponse(
         response_body(),

--- a/local_proxy/server.py
+++ b/local_proxy/server.py
@@ -449,9 +449,15 @@ def _register_control_routes(
             return JSONResponse(status_code=422, content={"detail": "provider_id 必须是字符串或 null"})
         thread_id = profile.router.thread_id_for_session_key(session_key)
         if thread_id is None:
-            thread_id = profile.usage_store.thread_id_for_session_key(session_key)
+            thread_id = await asyncio.to_thread(
+                profile.usage_store.thread_id_for_session_key,
+                session_key,
+            )
         if thread_id is None and profile.session_key_resolver is not None:
-            thread_id = profile.session_key_resolver(session_key)
+            thread_id = await asyncio.to_thread(
+                profile.session_key_resolver,
+                session_key,
+            )
         if thread_id is None:
             return JSONResponse(status_code=404, content={"detail": "未找到该会话"})
         if provider_id is not None:

--- a/tests/test_proxy_core.py
+++ b/tests/test_proxy_core.py
@@ -545,6 +545,37 @@ class UsageTests(unittest.TestCase):
                 now=now,
             )
 
+    def test_request_history_cleanup_is_throttled(self) -> None:
+        now = 2_000_000.0
+        self.store.request_history(now=now)
+        expired_at = now - 7 * 24 * 3600 - 1
+        with closing(sqlite3.connect(self.store.path)) as connection, connection:
+            connection.execute(
+                """
+                INSERT INTO request_history (
+                    started_at, finished_at, provider_id, session_name, model,
+                    succeeded, outcome, duration_ms, retry_count
+                ) VALUES (?, ?, 'provider-a', 'expired', 'gpt-5', 1,
+                          'succeeded', 0, 0)
+                """,
+                (expired_at, expired_at),
+            )
+
+        self.store.request_history(now=now + 1)
+        with closing(sqlite3.connect(self.store.path)) as connection:
+            retained_count = connection.execute(
+                "SELECT COUNT(*) FROM request_history WHERE session_name = 'expired'"
+            ).fetchone()[0]
+
+        self.store.request_history(now=now + 3600)
+        with closing(sqlite3.connect(self.store.path)) as connection:
+            cleaned_count = connection.execute(
+                "SELECT COUNT(*) FROM request_history WHERE session_name = 'expired'"
+            ).fetchone()[0]
+
+        self.assertEqual(retained_count, 1)
+        self.assertEqual(cleaned_count, 0)
+
     def test_request_history_includes_failures_and_paginates(self) -> None:
         now = 2_000_000.0
         records = (
@@ -1033,6 +1064,103 @@ api-version = "2026-07-01"
 
 
 class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
+    async def test_persistence_lock_does_not_block_following_upstream_request(self) -> None:
+        class LockingUsageStore(UsageStore):
+            def __init__(self, path: Path) -> None:
+                super().__init__(path)
+                self.history_locked = threading.Event()
+                self.persistence_waiting = threading.Event()
+                self.release_history = threading.Event()
+
+            def request_history(self, **kwargs):
+                with self._lock:
+                    self.history_locked.set()
+                    self.release_history.wait(timeout=2)
+                return {
+                    "window": kwargs["window"],
+                    "start_at": None,
+                    "end_at": None,
+                    "total_count": 0,
+                    "items": [],
+                    "next_cursor": None,
+                }
+
+            def record(self, **kwargs):
+                self.persistence_waiting.set()
+                return super().record(**kwargs)
+
+            def record_request(self, **kwargs):
+                self.persistence_waiting.set()
+                return super().record_request(**kwargs)
+
+        upstream_count = 0
+        second_upstream_started = threading.Event()
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            nonlocal upstream_count
+            upstream_count += 1
+            if upstream_count == 2:
+                second_upstream_started.set()
+            return httpx.Response(
+                200,
+                json={
+                    "id": f"response-{upstream_count}",
+                    "output": [],
+                    "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                },
+            )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            usage_store = LockingUsageStore(Path(temp_dir) / "usage.sqlite3")
+            upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+            app = create_proxy_app(
+                ProviderRouter((provider("selected", current=True),)),
+                client=upstream_client,
+                usage_store=usage_store,
+            )
+            client = httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            )
+            history_task = asyncio.create_task(client.get("/control/api/requests"))
+            first_task = None
+            second_task = None
+            watchdog = threading.Timer(1, usage_store.release_history.set)
+            try:
+                self.assertTrue(
+                    await asyncio.to_thread(usage_store.history_locked.wait, 1)
+                )
+                watchdog.start()
+                first_task = asyncio.create_task(
+                    client.post(
+                        "/v1/responses",
+                        json={"model": "gpt-test", "input": "first"},
+                    )
+                )
+                self.assertTrue(
+                    await asyncio.to_thread(usage_store.persistence_waiting.wait, 2)
+                )
+                second_task = asyncio.create_task(
+                    client.post(
+                        "/v1/responses",
+                        json={"model": "gpt-test", "input": "second"},
+                    )
+                )
+                self.assertTrue(
+                    await asyncio.to_thread(second_upstream_started.wait, 2)
+                )
+                self.assertFalse(usage_store.release_history.is_set())
+            finally:
+                usage_store.release_history.set()
+                watchdog.cancel()
+                tasks = [task for task in (history_task, first_task, second_task) if task]
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                await client.aclose()
+                await upstream_client.aclose()
+
+        self.assertTrue(all(isinstance(result, httpx.Response) for result in results))
+        self.assertTrue(all(result.status_code == 200 for result in results))
+
     async def test_request_api_hides_thread_id_and_persists_session_route(self) -> None:
         seen_hosts: list[str] = []
 
@@ -3396,6 +3524,101 @@ class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(history["items"][0]["succeeded"])
         self.assertIsNone(history["items"][0]["error_kind"])
         self.assertEqual(history["items"][0]["reasoning_effort"], "high")
+
+    async def test_cancelled_persistence_keeps_usage_and_request_history_linked(self) -> None:
+        class BlockingUsageStore(UsageStore):
+            def __init__(self, path: Path) -> None:
+                super().__init__(path)
+                self.usage_started = threading.Event()
+                self.release_usage = threading.Event()
+
+            def record(self, **kwargs):
+                self.usage_started.set()
+                self.release_usage.wait(timeout=2)
+                return super().record(**kwargs)
+
+        class CompletedStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield (
+                    b'data: {"type":"response.completed","response":{"usage":'
+                    b'{"input_tokens":12,"output_tokens":3,"total_tokens":15}}}\n\n'
+                )
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=CompletedStream(),
+            )
+
+        temp_context = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_context.cleanup)
+        usage_store = BlockingUsageStore(Path(temp_context.name) / "usage.sqlite3")
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            ProviderRouter((provider("selected", current=True),)),
+            client=upstream_client,
+            usage_store=usage_store,
+        )
+        route = next(
+            route for route in app.routes if getattr(route, "path", "") == "/v1/{upstream_path:path}"
+        )
+        from starlette.requests import Request
+
+        sent = False
+
+        async def receive():
+            nonlocal sent
+            if sent:
+                return {"type": "http.disconnect"}
+            sent = True
+            return {
+                "type": "http.request",
+                "body": b'{"model":"test"}',
+                "more_body": False,
+            }
+
+        scope = {
+            "type": "http", "method": "POST", "path": "/v1/responses",
+            "raw_path": b"/v1/responses", "query_string": b"", "headers": [],
+            "scheme": "http", "server": ("testserver", 80),
+            "client": ("127.0.0.1", 1), "root_path": "",
+        }
+        response = await route.endpoint("responses", Request(scope, receive))
+        iterator = response.body_iterator
+        self.assertIn(b"response.completed", await anext(iterator))
+        close_task = asyncio.create_task(iterator.aclose())
+        try:
+            self.assertTrue(await asyncio.to_thread(usage_store.usage_started.wait, 1))
+            close_task.cancel()
+            usage_store.release_usage.set()
+            with self.assertRaises(asyncio.CancelledError):
+                await close_task
+        finally:
+            usage_store.release_usage.set()
+
+        linked_usage_id = None
+        for _ in range(100):
+            with closing(sqlite3.connect(usage_store.path)) as connection:
+                row = connection.execute(
+                    "SELECT usage_id FROM request_history ORDER BY id DESC LIMIT 1"
+                ).fetchone()
+                linked_usage_id = None if row is None else row[0]
+            if linked_usage_id is not None:
+                break
+            await asyncio.sleep(0.01)
+        await upstream_client.aclose()
+
+        with closing(sqlite3.connect(usage_store.path)) as connection:
+            usage_count = connection.execute(
+                "SELECT COUNT(*) FROM request_usage"
+            ).fetchone()[0]
+            history_count = connection.execute(
+                "SELECT COUNT(*) FROM request_history"
+            ).fetchone()[0]
+        self.assertEqual(usage_count, 1)
+        self.assertEqual(history_count, 1)
+        self.assertIsNotNone(linked_usage_id)
 
     async def test_client_close_before_terminal_event_uses_short_cancel_summary(self) -> None:
         class PartialStream(httpx.AsyncByteStream):


### PR DESCRIPTION
## 变更说明
- 将请求记录、Token 与恢复记录移出 ASGI 事件循环，避免 SQLite 锁竞争拖停正常中转。
- 将流请求的 Token 与请求历史合并为单个后台持久化任务，避免取消时产生孤立 Token 和未知会话。
- 将请求历史清理改为一小时节流，并补充锁竞争、清理节流和取消完整性回归测试。
- 永久说明：`docs/changes/2026-08-14-nonblocking-request-persistence.md`

## 风险
- 请求结束阶段的内部操作顺序调整为先释放路由状态、再在线程中持久化；HTTP 接口、配置和 SQLite 表结构保持不变。
- 既有孤立 Token 不做破坏性清理，将随请求列表时间窗口自然退出。

## 验证
- Python 单元测试：435 项通过。
- Node 测试：40 项通过。
- JavaScript 语法、Python compileall、pre-commit、pre-push 和 diff 检查通过。
- Ruleset `agent-delivery-main`（ID `20543407`）验证通过。