### PR TITLE
📃 docs(changes): 补充状态服务供应商上传与管理 PR 记录

### DIFF
--- a/docs/changes/2026-08-20-status-provider-upload-pr-record.md
+++ b/docs/changes/2026-08-20-status-provider-upload-pr-record.md
@@ -1,0 +1,57 @@
++++
+id = "2026-08-20-status-provider-upload-pr-record"
+type = "docs"
+release_bump = "none"
+status = "verified"
++++
+
+# 状态服务供应商上传与管理 PR 记录补充
+
+## 目标
+
+在不改写已发布功能说明的前提下，补充状态服务供应商上传与远程监控管理功能的最终 PR、合并提交和 Release 对应关系。
+
+## 现状
+
+`docs/changes/2026-08-18-status-provider-upload.md`、`docs/changes/2026-08-19-status-upload-bootstrap-output.md`、`docs/changes/2026-08-19-status-upload-import-user.md`、`docs/changes/2026-08-19-status-upload-credential-dropin-order.md` 和 `docs/changes/2026-08-20-status-provider-management.md` 已随 v0.13.0 发布并保持不可变，其中 `2026-08-20-status-provider-management.md` 的 `PR` 字段仍为 `pending`，其余四份未记录 PR 字段。实际功能已通过 PR #37 合并到 `main`。
+
+## 设计范围
+
+- 记录上述五份功能说明对应的 PR URL、squash 合并提交和 Release URL。
+- 保留原功能说明不变，使用新的永久说明完成元数据补充。
+
+## 非目标
+
+- 不修改产品代码、配置、测试或构建工作流。
+- 不改写或删除已发布的原功能说明。
+- 不创建新的版本标签或发布产物。
+
+## 兼容性
+
+无接口、配置、数据或迁移影响。版本提升选择 `none`，因为本次仅补充发布元数据。
+
+## 风险
+
+主要风险是中文链接说明出现编码损坏；通过 UTF-8 解码检查和乱码候选扫描验证。
+
+## 测试计划
+
+- 运行 `git diff --check`。
+- 使用 Python 按 UTF-8 读取补充说明并扫描常见乱码字符。
+- 运行仓库 pre-commit 门禁。
+
+## 实际改动
+
+- 新增本说明，记录供应商上传与远程监控管理功能 PR 为 <https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/37>。
+- 记录 squash 合并提交为 `a37347652b0528b14afa5c454cd86b7a8761f8bb`。
+- 记录自动发布结果为 <https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/tag/v0.13.0>。
+
+## 验证结果
+
+- `git diff --check`：通过。
+- Python UTF-8 解码和常见乱码候选扫描：通过。
+- 仓库 pre-commit 门禁：通过。
+
+## PR
+
+pending


### PR DESCRIPTION
## 功能修改

- 新增 `docs/changes/2026-08-20-status-provider-upload-pr-record.md`，在不改写已发布说明的前提下，记录五份已发布功能说明对应的 PR #37、squash 合并提交 `a3734765` 与 v0.13.0 发布对应关系。
- 版本提升为 `none`，不触发新版本。

## 风险

无。仅新增 docs/changes 下永久元数据说明，不涉及产品代码、配置、测试或构建工作流。

## 验证结果

- `git diff --check`：通过。
- Python UTF-8 解码与乱码候选扫描：通过（无替换字符与 PUA 字符）。
- pre-commit 门禁与 pre-push 完整验证（461 项单测 + JS 语法检查）：通过。