### PR TITLE
🐞 fix(proxy): 修复跨供应商输入项 ID 拒绝

### DIFF
--- a/docs/changes/2026-08-20-input-item-id-repair.md
+++ b/docs/changes/2026-08-20-input-item-id-repair.md
@@ -1,0 +1,69 @@
++++
+id = "2026-08-20-input-item-id-repair"
+type = "feature"
+release_bump = "patch"
+status = "verified"
++++
+
+# Responses 输入项 ID 兼容修复
+
+## 目标
+
+当上游明确拒绝 `input[N].id` 时，代理删除该输入项的顶层 `id` 并对同一供应商进行一次受限重试；同一会话后续再次路由到该供应商时沿用兼容处理，避免长会话因旧供应商生成的 ID 持续失败。
+
+## 现状
+
+代理会将 `invalid_request_error` 视为永久错误并直接透传，Responses 请求体也会原样发送。长会话在供应商切换后可能携带当前上游不接受的输入项 ID。
+
+## 设计范围
+
+- 只识别 HTTP 400 且 `code=invalid_value`、`type=invalid_request_error`、`param=input[N].id` 的错误。
+- 只删除顶层 `input[]` 对象中被明确指出的 `id`，不生成新 ID。
+- 保留 `call_id`、`previous_response_id` 和其他字段。
+- 修复重试独立于普通临时错误重试，单次请求设置严格上限。
+- 按会话和供应商记录短期内存兼容状态；状态不保存真实 ID，不新增数据库迁移。
+- 被指出的索引不是对象、没有顶层字符串 `id`、越界或属于 `item_reference` 时保留原错误。
+
+## 非目标
+
+- 不修复其他参数错误、上下文超限、权限错误或模型错误。
+- 不删除 `call_id`、`previous_response_id`、工具参数中的嵌套 ID。
+- 不修改 Codex 原始会话文件或客户端请求内容。
+- 不修改供应商服务端数据。
+
+## 兼容性
+
+请求转发接口保持不变。修复只影响命中精确错误的 Responses 请求；兼容记忆为进程内存并带 TTL，重启后自动重新学习。无数据库结构变更。
+
+## 风险
+
+错误匹配过宽可能误改合法请求，因此采用严格字段匹配和 `item_reference` 排除。删除普通输入项顶层 `id` 是针对跨供应商兼容问题的工程推断，尚未通过真实上游成功/失败请求对照证明语义等价，因此兼容记忆仅按会话与供应商生效并设置 24 小时 TTL。重复坏 ID 可能形成循环，因此设置单请求修复上限并在失败时透传最后一次上游错误。
+
+## 测试计划
+
+- 精确识别 HTTP 400 的 `input[N].id` 错误并删除指定字段。
+- 修复后同供应商重试成功，且保留 `call_id` 与 `previous_response_id`。
+- 会话/供应商兼容状态只作用于匹配供应商，并在后续请求生效。
+- 普通永久 400、非法 JSON、越界索引和不安全输入项保持原样。
+- 多个坏 ID、上限、普通重试关闭及请求体不可变场景。
+
+## 实际改动
+
+- `local_proxy/core.py` 增加 `input[N].id` 精确错误识别和安全请求体派生，只删除非 `item_reference` 输入项的顶层字符串 `id`。
+- 修复重试固定在返回错误的供应商，不占用普通重试次数、不触发普通路由切换，单请求最多修复 8 个不同索引。
+- 新增按会话哈希和供应商 ID 隔离的 24 小时内存兼容状态，最多保留 4096 项；同一会话后续请求自动删除安全的输入项 ID。
+- `local_proxy/server.py` 为 Codex 协议配置独立兼容状态，Claude 协议不启用该处理。
+- `tests/test_proxy_core.py` 覆盖精确匹配、字段保留、TTL、普通重试关闭、供应商切换、修复上限、后续请求和非 Responses 路径。
+
+## 验证结果
+
+- `python -m py_compile local_proxy/core.py local_proxy/server.py tests/test_proxy_core.py`：通过。
+- `python -m unittest discover -s tests -p "test_*.py"`：469 项通过。
+- `node --check proxy_static/app.js`：通过。
+- `node --check provider_status/static/app.js`：通过。
+- 对 `tests/*.test.js` 逐文件执行 `node --test`：10 个文件、45 项通过。
+- `git diff --check`：通过。
+
+## PR
+
+pending

--- a/docs/changes/2026-08-20-input-item-id-repair.md
+++ b/docs/changes/2026-08-20-input-item-id-repair.md
@@ -66,4 +66,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/39

--- a/local_proxy/core.py
+++ b/local_proxy/core.py
@@ -40,6 +40,9 @@ RETRY_ERROR_BODY_BYTES = 4 * 1024
 RETRY_ERROR_HISTORY_LIMIT = 5
 RETRY_ERROR_MESSAGE_CHARS = 220
 RETRY_ERROR_READ_TIMEOUT_SECONDS = 0.25
+INPUT_ITEM_ID_COMPATIBILITY_TTL_SECONDS = 24 * 3600
+INPUT_ITEM_ID_COMPATIBILITY_MAX_ENTRIES = 4096
+MAX_INPUT_ITEM_ID_REPAIRS_PER_REQUEST = 8
 HTML_ERROR_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
 RECOVERY_HISTORY_HOURS = 24
 RECOVERY_HISTORY_API_LIMIT = 500
@@ -89,6 +92,7 @@ SSE_FAILURE_MARKER_RE = re.compile(
     rb'(?<!\\)"error"\s*:\s*(?:\{|"))',
     re.IGNORECASE,
 )
+INPUT_ITEM_ID_ERROR_PARAM_RE = re.compile(r"^input\[(0|[1-9][0-9]*)\]\.id$")
 
 
 class DisconnectAwareStreamingResponse(StreamingResponse):
@@ -1192,6 +1196,61 @@ def _decode_json(payload: bytes) -> Any | None:
         return None
 
 
+def _input_item_id_error_index(root: Any) -> int | None:
+    """Return the rejected input index only for the exact upstream error shape."""
+    if not isinstance(root, dict):
+        return None
+    response = root.get("response") if isinstance(root.get("response"), dict) else {}
+    candidates = (root, root.get("error"), response, response.get("error"))
+    for node in candidates:
+        if not isinstance(node, dict):
+            continue
+        if (
+            node.get("type") != "invalid_request_error"
+            or node.get("code") != "invalid_value"
+        ):
+            continue
+        match = INPUT_ITEM_ID_ERROR_PARAM_RE.fullmatch(str(node.get("param", "")))
+        if match is not None:
+            return int(match.group(1))
+    return None
+
+
+def _input_item_id_error_index_from_body(body: bytes) -> int | None:
+    return _input_item_id_error_index(_decode_json(body))
+
+
+def _strip_input_item_ids(
+    payload: bytes,
+    *,
+    only_indexes: Iterable[int] | None = None,
+) -> tuple[bytes | None, int]:
+    """Remove safe top-level Responses input item IDs from a fresh JSON copy."""
+    root = _decode_json(payload)
+    if not isinstance(root, dict) or not isinstance(root.get("input"), list):
+        return None, 0
+    items = root["input"]
+    changed = 0
+    indexes = range(len(items)) if only_indexes is None else tuple(only_indexes)
+    for index in indexes:
+        if not isinstance(index, int) or index < 0 or index >= len(items):
+            continue
+        item = items[index]
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "item_reference":
+            continue
+        if isinstance(item.get("id"), str):
+            item.pop("id", None)
+            changed += 1
+    if not changed:
+        return None, 0
+    try:
+        return json.dumps(root, ensure_ascii=False, separators=(",", ":")).encode("utf-8"), changed
+    except (TypeError, ValueError):
+        return None, 0
+
+
 def _normalize_reasoning_effort(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -1520,6 +1579,61 @@ class HealthStatusUrlStore:
         normalized = normalize_health_status_url(url)
         with self._lock:
             self._url = normalized
+
+
+class InputItemIdCompatibilityStore:
+    """Remember providers that reject replayed Responses input item IDs."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = INPUT_ITEM_ID_COMPATIBILITY_TTL_SECONDS,
+        max_entries: int = INPUT_ITEM_ID_COMPATIBILITY_MAX_ENTRIES,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._ttl_seconds = max(1.0, float(ttl_seconds))
+        self._max_entries = max(1, int(max_entries))
+        self._clock = clock
+        self._expires_at: dict[tuple[str, str], float] = {}
+
+    def should_strip(self, thread_id: str | None, provider_id: str) -> bool:
+        key = self._key(thread_id, provider_id)
+        if key is None:
+            return False
+        now = self._clock()
+        with self._lock:
+            expires_at = self._expires_at.get(key)
+            if expires_at is None:
+                return False
+            if expires_at <= now:
+                self._expires_at.pop(key, None)
+                return False
+            return True
+
+    def remember(self, thread_id: str | None, provider_id: str) -> None:
+        key = self._key(thread_id, provider_id)
+        if key is None:
+            return
+        now = self._clock()
+        with self._lock:
+            self._remove_expired(now)
+            if key not in self._expires_at and len(self._expires_at) >= self._max_entries:
+                oldest = min(self._expires_at, key=self._expires_at.__getitem__)
+                self._expires_at.pop(oldest, None)
+            self._expires_at[key] = now + self._ttl_seconds
+
+    def _remove_expired(self, now: float) -> None:
+        for key, expires_at in tuple(self._expires_at.items()):
+            if expires_at <= now:
+                self._expires_at.pop(key, None)
+
+    @staticmethod
+    def _key(thread_id: str | None, provider_id: str) -> tuple[str, str] | None:
+        session_key = _session_key(thread_id)
+        if session_key is None or not provider_id:
+            return None
+        return session_key, provider_id
 
 
 def retry_policy_from_mapping(payload: Any) -> RetryPolicy:
@@ -2006,6 +2120,7 @@ def create_proxy_app(
     session_name_resolver: Callable[[Iterable[str]], Mapping[str, str]] | None = None,
     session_catalog: Callable[[float], Iterable[Mapping[str, Any]]] | None = None,
     session_key_resolver: Callable[[str], str | None] | None = None,
+    input_item_id_compatibility_store: InputItemIdCompatibilityStore | None = None,
     config_endpoint_name: str = "codex-config",
     codex_profile: Any | None = None,
     claude_profile: Any | None = None,
@@ -2052,6 +2167,13 @@ def create_proxy_app(
     active_health_status_url_store = health_status_url_store or HealthStatusUrlStore(
         health_status_url
     )
+    active_input_item_id_compatibility_store = input_item_id_compatibility_store
+    if (
+        active_input_item_id_compatibility_store is None
+        and service_name == "codex-local-proxy"
+        and protocol_adapter is None
+    ):
+        active_input_item_id_compatibility_store = InputItemIdCompatibilityStore()
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
@@ -2531,6 +2653,7 @@ def create_proxy_app(
             recovery_history_store=recovery_history_store,
             protocol_adapter=protocol_adapter,
             session_name_resolver=session_name_resolver,
+            input_item_id_compatibility_store=active_input_item_id_compatibility_store,
         )
 
     return app
@@ -3103,6 +3226,7 @@ async def _forward_request(
     recovery_history_store: RecoveryHistoryStore | None = None,
     protocol_adapter: Any | None = None,
     session_name_resolver: Callable[[Iterable[str]], Mapping[str, str]] | None = None,
+    input_item_id_compatibility_store: InputItemIdCompatibilityStore | None = None,
 ):
     thread_id = _codex_thread_id(request.headers)
     try:
@@ -3189,10 +3313,15 @@ async def _forward_request(
     final_summary: str | None = None
     response_body_decoded = False
     attempt = 1
+    item_id_repairs = 0
+    repaired_item_indexes_by_provider: dict[str, set[int]] = {}
+    responses_request = upstream_path.strip("/").casefold() == "responses"
+    reroute_before_attempt = True
     while True:
         response_body_decoded = False
-        if attempt > 1:
+        if attempt > 1 and reroute_before_attempt:
             snapshot, _ = router.route_retry_to_current(snapshot)
+        reroute_before_attempt = True
         provider = snapshot.provider
         if not provider.has_credentials:
             final_error = "credential_missing"
@@ -3219,6 +3348,24 @@ async def _forward_request(
             for key, value in provider.default_query.items()
             if key not in existing_keys
         )
+        request_body_for_attempt = request_body
+        repaired_indexes = repaired_item_indexes_by_provider.get(provider.provider_id, set())
+        strip_all_input_item_ids = (
+            responses_request
+            and not repaired_indexes
+            and input_item_id_compatibility_store is not None
+            and input_item_id_compatibility_store.should_strip(
+                thread_id,
+                provider.provider_id,
+            )
+        )
+        if strip_all_input_item_ids or repaired_indexes:
+            transformed_body, _ = _strip_input_item_ids(
+                request_body,
+                only_indexes=None if strip_all_input_item_ids else repaired_indexes,
+            )
+            if transformed_body is not None:
+                request_body_for_attempt = transformed_body
         retry_kind: str | None = None
         retry_summary: str | None = None
         retry_delay = retry_policy.backoff(attempt - 1)
@@ -3228,7 +3375,7 @@ async def _forward_request(
                 url,
                 params=query_items,
                 headers=headers,
-                content=request_body,
+                content=request_body_for_attempt,
             )
             upstream_response = await client.send(upstream_request, stream=True)
             retry_kind = None
@@ -3275,16 +3422,55 @@ async def _forward_request(
                     retry_kind is None
                     and first_chunk is not None
                     and upstream_response.status_code == 400
-                    and retry_policy.enabled
+                    and (
+                        retry_policy.enabled
+                        or (
+                            responses_request
+                            and input_item_id_compatibility_store is not None
+                        )
+                    )
                 ):
                     assert stream is not None
-                    first_chunk, stream, retry_kind, retry_summary = (
+                    first_chunk, stream, retry_kind, retry_summary, repair_index = (
                         await _inspect_http_400_before_output(
                             upstream_response,
                             first_chunk,
                             stream,
+                            detect_retryable=retry_policy.enabled,
                         )
                     )
+                    repair_applied = False
+                    if (
+                        responses_request
+                        and repair_index is not None
+                        and item_id_repairs < MAX_INPUT_ITEM_ID_REPAIRS_PER_REQUEST
+                        and repair_index not in repaired_indexes
+                    ):
+                        transformed_body, changed = _strip_input_item_ids(
+                            request_body,
+                            only_indexes=(repair_index,),
+                        )
+                        if transformed_body is not None and changed == 1:
+                            repaired_item_indexes_by_provider.setdefault(
+                                provider.provider_id,
+                                set(),
+                            ).add(repair_index)
+                            item_id_repairs += 1
+                            if input_item_id_compatibility_store is not None:
+                                input_item_id_compatibility_store.remember(
+                                    thread_id,
+                                    provider.provider_id,
+                                )
+                            retry_kind = "request_item_id_repair"
+                            retry_summary = (
+                                f"请求体兼容修复：已移除 input[{repair_index}].id"
+                            )
+                            final_error = retry_kind
+                            retry_delay = 0.0
+                            repair_applied = True
+                    if repair_index is not None and not repair_applied:
+                        retry_kind = None
+                        retry_summary = None
                     if retry_kind is not None:
                         final_error = retry_kind
                 if (
@@ -3344,7 +3530,10 @@ async def _forward_request(
         )
         can_retry = (
             retry_kind is not None
-            and retry_policy.allows_attempt(attempt + 1)
+            and (
+                retry_kind == "request_item_id_repair"
+                or retry_policy.allows_attempt(attempt + 1)
+            )
             and not request_disconnected
         )
         if retry_kind is not None and retry_summary is None and upstream_response is not None:
@@ -3374,32 +3563,41 @@ async def _forward_request(
                 )
             break
         failed_provider_id = snapshot.provider.provider_id
-        snapshot, rerouted = router.route_retry_to_current(snapshot)
-        if rerouted:
-            retry_delay = 0.0
-        router.record_retry(
-            snapshot,
-            attempt=attempt + 1,
-            max_attempts=retry_policy.max_attempts,
-            delay_seconds=retry_delay,
-            kind=retry_kind,
-            error_summary=retry_summary,
-            error_provider_id=failed_provider_id,
-        )
+        rerouted = False
+        if retry_kind != "request_item_id_repair":
+            snapshot, rerouted = router.route_retry_to_current(snapshot)
+            if rerouted:
+                retry_delay = 0.0
+            router.record_retry(
+                snapshot,
+                attempt=attempt + 1,
+                max_attempts=retry_policy.max_attempts,
+                delay_seconds=retry_delay,
+                kind=retry_kind,
+                error_summary=retry_summary,
+                error_provider_id=failed_provider_id,
+            )
         await _record_recovery_event_async(
             recovery_history_store,
             snapshot=snapshot,
             provider_id=failed_provider_id,
             attempt=attempt,
-            max_attempts=retry_policy.max_attempts,
+            max_attempts=(
+                MAX_INPUT_ITEM_ID_REPAIRS_PER_REQUEST + 1
+                if retry_kind == "request_item_id_repair"
+                else retry_policy.max_attempts
+            ),
             delay_seconds=retry_delay,
             kind=retry_kind,
             summary=retry_summary,
             stage="before_output",
             outcome="retrying",
         )
-        await retry_sleep(retry_delay)
-        attempt += 1
+        if retry_kind == "request_item_id_repair":
+            reroute_before_attempt = False
+        else:
+            await retry_sleep(retry_delay)
+            attempt += 1
 
     if upstream_response is None or stream is None:
         router.record_outcome(snapshot, transient_failure=True, policy=retry_policy)
@@ -3437,9 +3635,9 @@ async def _forward_request(
     usage_capture = None
     if usage_store is not None:
         usage_capture = (
-            protocol_adapter.usage_capture(request_body, upstream_path)
+            protocol_adapter.usage_capture(request_body_for_attempt, upstream_path)
             if protocol_adapter is not None
-            else UsageCapture(request_body, upstream_path)
+            else UsageCapture(request_body_for_attempt, upstream_path)
         )
     failure_capture = None
     if (
@@ -3575,18 +3773,31 @@ async def _inspect_http_400_before_output(
     response: httpx.Response,
     first_chunk: bytes,
     stream: AsyncIterator[bytes],
+    *,
+    detect_retryable: bool = True,
 ) -> tuple[
     bytes | None,
     AsyncIterator[bytes],
     str | None,
     str | None,
+    int | None,
 ]:
     buffered = bytearray(first_chunk[:RETRY_ERROR_BODY_BYTES])
     first_remainder = first_chunk[RETRY_ERROR_BODY_BYTES:]
     if first_remainder:
+        repair_index = _input_item_id_error_index_from_body(bytes(buffered))
+        if repair_index is not None:
+            return (
+                bytes(buffered),
+                _resume_async_iterator(stream, prefix=first_remainder),
+                "request_item_id_repair",
+                f"请求体兼容修复：上游拒绝 input[{repair_index}].id",
+                repair_index,
+            )
         return (
             bytes(buffered),
             _resume_async_iterator(stream, prefix=first_remainder),
+            None,
             None,
             None,
         )
@@ -3603,29 +3814,50 @@ async def _inspect_http_400_before_output(
                     _resume_async_iterator(stream, pending=next_chunk),
                     None,
                     None,
+                    None,
                 )
             chunk = next_chunk.result()
         except StopAsyncIteration:
-            retry_kind, retry_summary = _http_400_retry_failure(
-                response,
-                bytes(buffered),
-            )
-            if retry_kind is not None:
-                return None, stream, retry_kind, retry_summary
-            return bytes(buffered), stream, None, None
+            repair_index = _input_item_id_error_index_from_body(bytes(buffered))
+            if repair_index is not None:
+                return (
+                    bytes(buffered),
+                    stream,
+                    "request_item_id_repair",
+                    f"请求体兼容修复：上游拒绝 input[{repair_index}].id",
+                    repair_index,
+                )
+            if detect_retryable:
+                retry_kind, retry_summary = _http_400_retry_failure(
+                    response,
+                    bytes(buffered),
+                )
+                if retry_kind is not None:
+                    return None, stream, retry_kind, retry_summary, None
+            return bytes(buffered), stream, None, None, None
         except httpx.HTTPError as exc:
             return (
                 None,
                 stream,
                 "stream_start",
                 _exception_retry_summary("stream_start", exc),
+                None,
             )
         remaining = RETRY_ERROR_BODY_BYTES - len(buffered)
         buffered.extend(chunk[:remaining])
         chunk_remainder = chunk[remaining:]
         if chunk_remainder:
             stream = _resume_async_iterator(stream, prefix=chunk_remainder)
-    return bytes(buffered), stream, None, None
+    repair_index = _input_item_id_error_index_from_body(bytes(buffered))
+    if repair_index is not None:
+        return (
+            bytes(buffered),
+            stream,
+            "request_item_id_repair",
+            f"请求体兼容修复：上游拒绝 input[{repair_index}].id",
+            repair_index,
+        )
+    return bytes(buffered), stream, None, None, None
 
 
 async def _resume_async_iterator(

--- a/local_proxy/server.py
+++ b/local_proxy/server.py
@@ -24,6 +24,7 @@ from local_proxy.core import (
     REQUEST_HISTORY_WINDOWS,
     USAGE_WINDOWS,
     HealthStatusUrlStore,
+    InputItemIdCompatibilityStore,
     ProviderConfigurationError,
     ProviderRouter,
     ProxyProvider,
@@ -117,6 +118,7 @@ class ProxyProfile:
     session_name_resolver: Callable[[Iterable[str]], Mapping[str, str]] | None = None
     session_catalog: Callable[[float], Iterable[Mapping[str, Any]]] | None = None
     session_key_resolver: Callable[[str], str | None] | None = None
+    input_item_id_compatibility_store: InputItemIdCompatibilityStore | None = None
     config_endpoint_name: str = "config"
     owns_client: bool = True
     retry_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep
@@ -125,6 +127,8 @@ class ProxyProfile:
     def __post_init__(self) -> None:
         self.retry_policy_store = self.retry_policy_store or RetryPolicyStore(self.retry_policy)
         self.health_status_url_store = self.health_status_url_store or HealthStatusUrlStore()
+        if self.service_id == "codex" and self.input_item_id_compatibility_store is None:
+            self.input_item_id_compatibility_store = InputItemIdCompatibilityStore()
         self.active_hidden_provider_ids = {
             provider_id
             for provider_id in self.hidden_provider_ids
@@ -243,6 +247,7 @@ def create_unified_proxy_app(
             recovery_history_store=profile.recovery_history_store,
             protocol_adapter=profile.protocol_adapter,
             session_name_resolver=profile.session_name_resolver,
+            input_item_id_compatibility_store=profile.input_item_id_compatibility_store,
         )
 
     return app

--- a/tests/test_proxy_core.py
+++ b/tests/test_proxy_core.py
@@ -16,6 +16,7 @@ import httpx
 
 from local_proxy.core import (
     HealthStatusUrlStore,
+    InputItemIdCompatibilityStore,
     LocalProxyServer,
     ProviderRouter,
     ProxyProvider,
@@ -28,6 +29,8 @@ from local_proxy.core import (
     RETRY_ERROR_BODY_BYTES,
     _codex_thread_id,
     _inspect_http_400_before_output,
+    _input_item_id_error_index,
+    _strip_input_item_ids,
     _public_control_status,
     _public_requests,
     _request_reasoning_effort,
@@ -1063,7 +1066,301 @@ api-version = "2026-07-01"
         self.assertEqual(loaded.default_query, {"api-version": "2026-07-01"})
 
 
+class InputItemIdCompatibilityTests(unittest.TestCase):
+    def test_store_is_scoped_to_session_and_provider(self) -> None:
+        now = [100.0]
+        store = InputItemIdCompatibilityStore(
+            ttl_seconds=10,
+            clock=lambda: now[0],
+        )
+
+        store.remember("thread-a", "provider-a")
+
+        self.assertTrue(store.should_strip("thread-a", "provider-a"))
+        self.assertFalse(store.should_strip("thread-a", "provider-b"))
+        self.assertFalse(store.should_strip("thread-b", "provider-a"))
+        self.assertFalse(store.should_strip(None, "provider-a"))
+        now[0] = 111.0
+        self.assertFalse(store.should_strip("thread-a", "provider-a"))
+
+    def test_strip_input_item_ids_keeps_references_and_call_ids(self) -> None:
+        payload = json.dumps(
+            {
+                "previous_response_id": "resp_old",
+                "input": [
+                    {"type": "message", "id": "msg_old", "role": "user"},
+                    {"type": "function_call", "id": "fc_old", "call_id": "call_1"},
+                    {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+                    {"type": "item_reference", "id": "msg_reference"},
+                ],
+            },
+            ensure_ascii=False,
+        ).encode()
+
+        stripped, changed = _strip_input_item_ids(payload)
+
+        self.assertIsNotNone(stripped)
+        self.assertEqual(changed, 2)
+        root = json.loads(stripped)
+        self.assertEqual(root["previous_response_id"], "resp_old")
+        self.assertNotIn("id", root["input"][0])
+        self.assertNotIn("id", root["input"][1])
+        self.assertEqual(root["input"][1]["call_id"], "call_1")
+        self.assertEqual(root["input"][2]["call_id"], "call_1")
+        self.assertEqual(root["input"][3]["id"], "msg_reference")
+
+    def test_error_index_requires_exact_invalid_input_id_shape(self) -> None:
+        self.assertEqual(
+            _input_item_id_error_index(
+                {
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "invalid_value",
+                        "param": "input[147].id",
+                    }
+                }
+            ),
+            147,
+        )
+        self.assertIsNone(
+            _input_item_id_error_index(
+                {
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "invalid_value",
+                        "param": "input[147].role",
+                    }
+                }
+            )
+        )
+
+
 class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invalid_input_item_id_is_repaired_without_normal_retry_policy(self) -> None:
+        attempts: list[dict] = []
+        thread_id = "thread-item-id-repair"
+        body = {
+            "model": "test",
+            "previous_response_id": "resp_old",
+            "input": [
+                {"type": "message", "id": "bad_message_id", "role": "user", "content": "hi"},
+                {"type": "function_call", "id": "bad_call_id", "call_id": "call_1"},
+            ],
+        }
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            parsed = json.loads(request.content)
+            attempts.append(parsed)
+            if len(attempts) == 1:
+                return httpx.Response(
+                    400,
+                    headers={"content-type": "application/json"},
+                    json={
+                        "error": {
+                            "type": "invalid_request_error",
+                            "code": "invalid_value",
+                            "param": "input[0].id",
+                        }
+                    },
+                )
+            return httpx.Response(200, content=b"recovered")
+
+        router = ProviderRouter((provider("selected", current=True),))
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            router,
+            client=upstream_client,
+            retry_policy=RetryPolicy(enabled=False),
+            input_item_id_compatibility_store=InputItemIdCompatibilityStore(),
+        )
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post(
+            "/v1/responses",
+            headers={
+                "x-codex-turn-metadata": json.dumps({"thread_id": thread_id}),
+            },
+            json=body,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(attempts), 2)
+        self.assertIn("id", attempts[0]["input"][0])
+        self.assertNotIn("id", attempts[1]["input"][0])
+        self.assertIn("id", attempts[1]["input"][1])
+        self.assertEqual(attempts[1]["previous_response_id"], "resp_old")
+        self.assertEqual(attempts[1]["input"][1]["call_id"], "call_1")
+
+    async def test_input_item_id_compatibility_applies_to_following_request(self) -> None:
+        seen: list[dict] = []
+        thread_id = "thread-item-id-memory"
+        compatibility = InputItemIdCompatibilityStore()
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            seen.append(json.loads(request.content))
+            return httpx.Response(200, content=b"ok")
+
+        router = ProviderRouter((provider("selected", current=True),))
+        compatibility.remember(thread_id, "selected")
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            router,
+            client=upstream_client,
+            input_item_id_compatibility_store=compatibility,
+        )
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post(
+            "/v1/responses",
+            headers={"x-codex-turn-metadata": json.dumps({"thread_id": thread_id})},
+            json={
+                "model": "test",
+                "input": [{"type": "message", "id": "old", "role": "user"}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("id", seen[0]["input"][0])
+
+    async def test_item_id_repair_stays_on_the_rejecting_provider(self) -> None:
+        seen_hosts: list[str] = []
+        router = ProviderRouter(
+            (provider("first", current=True), provider("second")),
+        )
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            seen_hosts.append(request.url.host)
+            if len(seen_hosts) == 1:
+                router.select("second")
+                return httpx.Response(
+                    400,
+                    json={
+                        "error": {
+                            "type": "invalid_request_error",
+                            "code": "invalid_value",
+                            "param": "input[0].id",
+                        }
+                    },
+                )
+            return httpx.Response(200, content=b"ok")
+
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(router, client=upstream_client)
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post(
+            "/v1/responses",
+            headers={"x-codex-turn-metadata": json.dumps({"thread_id": "thread-a"})},
+            json={
+                "model": "test",
+                "input": [{"type": "message", "id": "old", "role": "user"}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            seen_hosts,
+            ["first.example.test", "first.example.test"],
+        )
+
+    async def test_item_id_repair_stops_at_strict_limit(self) -> None:
+        attempts = 0
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
+            root = json.loads(request.content)
+            bad_index = next(
+                index for index, item in enumerate(root["input"]) if "id" in item
+            )
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "invalid_value",
+                        "param": f"input[{bad_index}].id",
+                    }
+                },
+            )
+
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            ProviderRouter((provider("selected", current=True),)),
+            client=upstream_client,
+        )
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post(
+            "/v1/responses",
+            headers={"x-codex-turn-metadata": json.dumps({"thread_id": "thread-limit"})},
+            json={
+                "model": "test",
+                "input": [
+                    {"type": "message", "id": f"old-{index}", "role": "user"}
+                    for index in range(9)
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["param"], "input[8].id")
+        self.assertEqual(attempts, 9)
+
+    async def test_item_id_error_is_not_repaired_outside_responses(self) -> None:
+        attempts = 0
+        error = {
+            "error": {
+                "type": "invalid_request_error",
+                "code": "invalid_value",
+                "param": "input[0].id",
+            }
+        }
+
+        async def upstream(_: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
+            return httpx.Response(400, json=error)
+
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            ProviderRouter((provider("selected", current=True),)),
+            client=upstream_client,
+        )
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "input": [{"type": "message", "id": "old", "role": "user"}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), error)
+        self.assertEqual(attempts, 1)
+
     async def test_persistence_lock_does_not_block_following_upstream_request(self) -> None:
         class LockingUsageStore(UsageStore):
             def __init__(self, path: Path) -> None:
@@ -2662,7 +2959,7 @@ class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
         )
         stream = remaining_chunks()
 
-        buffered, resumed_stream, retry_kind, retry_summary = (
+        buffered, resumed_stream, retry_kind, retry_summary, repair_index = (
             await _inspect_http_400_before_output(
                 response,
                 first_chunk,
@@ -2676,6 +2973,7 @@ class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(remainder, b"overflow" + trailing_chunk)
         self.assertIsNone(retry_kind)
         self.assertIsNone(retry_summary)
+        self.assertIsNone(repair_index)
 
     async def test_sniffed_nginx_404_exhausts_without_html_leak(self) -> None:
         attempts = 0


### PR DESCRIPTION
## 功能说明

- 精确识别 Responses 返回的 `invalid_request_error / invalid_value / input[N].id`。
- 删除上游明确拒绝的普通输入项顶层 `id`，固定在同一供应商立即受限重试。
- 保留 `call_id`、`previous_response_id` 与 `item_reference.id`。
- 按会话与供应商记录 24 小时进程内兼容状态，单请求最多修复 8 个索引。

## 风险

删除普通输入项顶层 ID 是针对跨供应商重放问题的兼容性推断，尚未通过真实上游成功/失败请求对照证明语义等价。处理范围采用精确错误匹配、会话/供应商隔离、TTL 与修复上限约束。

## 验证

- `python -m py_compile local_proxy/core.py local_proxy/server.py tests/test_proxy_core.py`
- `python -m unittest discover -s tests -p "test_*.py"`：469 项通过
- `node --check proxy_static/app.js`
- `node --check provider_status/static/app.js`
- 逐文件执行 `tests/*.test.js`：10 个文件、45 项通过
- `git diff --check`

功能说明：`docs/changes/2026-08-20-input-item-id-repair.md`