### PR TITLE
🐞 fix(proxy): 修复源码运行版本标识

### DIFF
--- a/docs/changes/2026-08-21-source-runtime-version.md
+++ b/docs/changes/2026-08-21-source-runtime-version.md
@@ -1,0 +1,63 @@
++++
+id = "2026-08-21-source-runtime-version"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 修复源码运行版本标识
+
+## 目标
+
+从 Git 工作树启动本地中转时，控制台和更新接口展示当前代码对应的最近正式版本，不再长期显示过期的开发默认版本。
+
+## 现状
+
+`local_proxy/application.py` 将 `APP_VERSION` 固定为 `0.1.7`。发布工作流会在打包前按标签临时改写该常量，因此便携版版本正确；直接运行最新源码时不会经过该步骤，更新接口仍把 `0.1.7` 当作当前版本并错误提示存在跨多个版本的更新。
+
+## 设计范围
+
+- 源码运行且仓库元数据可用时，从当前提交最近可达的严格 `v<major>.<minor>.<patch>` 标签解析版本。
+- 打包运行或 Git 信息不可用、标签格式无效、命令失败时，继续使用内置版本作为安全回退。
+- 保持现有纯三段 SemVer 输出，兼容在线更新比较逻辑和发布工作流的版本注入。
+- 增加自动化测试覆盖标签解析、回退和打包运行边界。
+
+## 非目标
+
+- 不改变发布标签生成、自动发版或便携包在线更新流程。
+- 不在版本号中加入提交哈希、分支名或脏工作树标记。
+- 不自动重启已经运行的源码进程。
+
+## 兼容性
+
+无接口、配置、数据库或迁移变化。更新接口的 `current_version` 仍为三段 SemVer 字符串。选择 `patch`，因为这是源码运行场景下版本识别错误的缺陷修复。
+
+## 风险
+
+运行环境可能没有 Git、没有标签或不在完整仓库中；实现必须捕获这些情况并回退到内置版本，避免版本检测阻止程序启动。浅克隆只要包含最近标签即可解析，否则同样安全回退。
+
+## 测试计划
+
+- 新增版本解析单元测试，覆盖有效标签、无效输出、命令失败和打包环境。
+- 运行 Python 全量单元测试。
+- 运行 JavaScript 语法检查和 JavaScript 全量测试。
+- 运行源码 `--version` 并核对更新接口相关测试。
+
+## 实际改动
+
+- `local_proxy/version.py`：新增源码版本解析，非打包环境从当前提交最近可达的严格 SemVer Git 标签取版本；打包环境、Git 命令失败和无效标签均回退到注入版本。
+- `local_proxy/application.py`：保留发布工作流可替换的 `APP_VERSION` 常量，并在源码运行时通过统一解析函数校正版本。
+- `tests/test_version.py`：覆盖源码标签解析、打包环境不调用 Git、无效标签和 Git 失败回退。
+
+## 验证结果
+
+- `.venv\\Scripts\\python.exe -m unittest tests.test_version tests.test_windows_release tests.test_macos_release`：12 tests passed。
+- `.venv\\Scripts\\python.exe local_proxy_app.py --version`：输出 `0.13.2`。
+- `.venv\\Scripts\\python.exe -m unittest discover -s tests -p "test_*.py"`：480 tests passed。
+- `node --check proxy_static/app.js`：通过。
+- `node --check provider_status/static/app.js`：通过。
+- `Get-ChildItem tests -Filter *.test.js | ForEach-Object { node --test $_.FullName }`：全部 JavaScript 测试通过。
+
+## PR
+
+pending

--- a/local_proxy/application.py
+++ b/local_proxy/application.py
@@ -51,9 +51,11 @@ from local_proxy.shared_settings import (
     save_shared_settings as save_settings,
     shared_settings_path as settings_path,
 )
+from local_proxy.version import resolve_app_version
 
 
 APP_VERSION = "0.1.7"
+APP_VERSION = resolve_app_version(APP_VERSION)
 AUTO_START_VALUE_NAME = "CodexLocalProxy"
 AUTO_START_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 

--- a/local_proxy/version.py
+++ b/local_proxy/version.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+
+VERSION_TAG_RE = re.compile(r"^v(\d+\.\d+\.\d+)$")
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def resolve_app_version(
+    fallback: str,
+    *,
+    frozen: bool | None = None,
+    repository: Path | None = None,
+    runner: CommandRunner = subprocess.run,
+) -> str:
+    """Resolve a source checkout version without weakening packaged builds."""
+    is_frozen = bool(getattr(sys, "frozen", False)) if frozen is None else frozen
+    if is_frozen:
+        return fallback
+
+    repository = repository or Path(__file__).resolve().parents[1]
+    command: Sequence[str] = (
+        "git",
+        "describe",
+        "--tags",
+        "--match",
+        "v[0-9]*",
+        "--abbrev=0",
+        "HEAD",
+    )
+    try:
+        result = runner(
+            command,
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return fallback
+
+    match = VERSION_TAG_RE.fullmatch(result.stdout.strip())
+    return match.group(1) if match is not None else fallback

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,58 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+from local_proxy.version import resolve_app_version
+
+
+class AppVersionTests(unittest.TestCase):
+    def test_source_checkout_uses_latest_reachable_release_tag(self) -> None:
+        calls = []
+
+        def run(command, **options):
+            calls.append((command, options))
+            return subprocess.CompletedProcess(command, 0, stdout="v0.13.2\n")
+
+        version = resolve_app_version(
+            "0.1.7",
+            frozen=False,
+            repository=Path("checkout"),
+            runner=run,
+        )
+
+        self.assertEqual(version, "0.13.2")
+        self.assertEqual(calls[0][0][-1], "HEAD")
+        self.assertEqual(calls[0][1]["cwd"], Path("checkout"))
+        self.assertTrue(calls[0][1]["check"])
+        self.assertEqual(calls[0][1]["timeout"], 2)
+
+    def test_packaged_runtime_keeps_injected_version(self) -> None:
+        def fail_if_called(*args, **kwargs):
+            self.fail("packaged runtime must not invoke git")
+
+        self.assertEqual(
+            resolve_app_version("0.13.2", frozen=True, runner=fail_if_called),
+            "0.13.2",
+        )
+
+    def test_invalid_tag_falls_back_to_injected_version(self) -> None:
+        def run(command, **options):
+            return subprocess.CompletedProcess(command, 0, stdout="v0.13\n")
+
+        self.assertEqual(
+            resolve_app_version("0.1.7", frozen=False, runner=run),
+            "0.1.7",
+        )
+
+    def test_git_failure_falls_back_to_injected_version(self) -> None:
+        def run(command, **options):
+            raise subprocess.CalledProcessError(128, command)
+
+        self.assertEqual(
+            resolve_app_version("0.1.7", frozen=False, runner=run),
+            "0.1.7",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
功能修改
- 源码运行时从最近可达的正式 Git 标签解析应用版本。
- 打包环境和 Git 不可用时保留注入版本回退，并补充版本解析测试。

影响范围
- 本地中转控制台更新接口和 --version 输出；无接口、配置、数据库迁移变化。
- 发布构建继续以 release tag 注入版本，不改变便携版流程。

验证结果
- Python 全量 480 tests passed。
- JavaScript 语法检查和全部 JavaScript 测试通过。
- 源码 --version 输出 0.13.2。