### PR TITLE
📃 docs(readme): 提供双语教程并更新 v1 仓库定位

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,396 @@
+# Codex Provider Hub
+
+[简体中文](README.md) | [English](README.en.md)
+
+<div align="center">
+
+Manage multiple API providers for Codex and Claude Code in one local application, with browser-based switching, pre-output retries, request history, token usage, and remote health monitoring.
+
+![Python](https://img.shields.io/badge/Python-3.11%2B-3776ab?style=flat-square)
+![FastAPI](https://img.shields.io/badge/FastAPI-0.115%2B-009688?style=flat-square)
+![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-4b5563?style=flat-square)
+[![License](https://img.shields.io/badge/License-AGPL--3.0--or--later-663399?style=flat-square)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/AI-Routing-Research-Institute/codex-provider-hub?style=flat-square)](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest)
+
+</div>
+
+## Contents
+
+- [Who this is for](#who-this-is-for)
+- [Five-minute quick start](#five-minute-quick-start)
+- [Recommended with CC Switch](#recommended-with-cc-switch)
+- [Configure Codex](#configure-codex)
+- [Configure Claude Code](#configure-claude-code)
+- [Manage and switch providers](#manage-and-switch-providers)
+- [Request transport](#request-transport)
+- [Retry, usage, and monitoring](#retry-usage-and-monitoring)
+- [Troubleshooting](#troubleshooting)
+- [Other installation methods](#other-installation-methods)
+- [Development and deployment](#development-and-deployment)
+- [Security boundaries](#security-boundaries)
+- [Open-source and commercial licensing](#open-source-and-commercial-licensing)
+
+## Who this is for
+
+Codex Provider Hub is designed for users who:
+
+- Use multiple Codex API or Claude Code API relays and want to switch between them immediately in a browser.
+- Already manage providers with CC Switch and want Codex and Claude Code to share one local application.
+- Need pre-output retries, request history, token usage, provider monitoring, and diagnostics.
+- Use providers that reject ordinary Python HTTP clients and need per-provider `curl_cffi` compatibility transport.
+
+It is not an API provider, does not supply API keys, and is not a general-purpose gateway for public multi-tenant deployment. You must provide your own legitimate provider endpoints and credentials.
+
+The application listens only on `127.0.0.1:17890` by default. One process serves two independent control panels:
+
+```text
+Codex       http://127.0.0.1:17890/control/codex/
+Claude Code http://127.0.0.1:17890/control/claude/
+```
+
+## Five-minute quick start
+
+### 1. Prepare CC Switch
+
+Install and configure CC Switch first. Add at least one Codex or Claude Code provider. Its default database location is:
+
+```text
+~/.cc-switch/cc-switch.db
+```
+
+The unified application builds both the Codex and Claude Code control panels at startup, so make sure this database exists and is readable before launching it.
+
+### 2. Download the application
+
+Windows x64:
+
+- [Download CodexLocalProxy-win-x64.exe](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe)
+- [Download the SHA-256 checksum](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe.sha256)
+
+macOS Apple Silicon:
+
+- [Download CodexLocalProxy-macos-arm64.zip](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip)
+- [Download the SHA-256 checksum](https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip.sha256)
+
+### 3. Start the application
+
+On Windows, double-click the EXE. It starts silently and remains in the notification area without opening a browser. Right-click the tray icon to open either control panel, configure startup at sign-in, or exit.
+
+On macOS, extract the `.app`. The current package is not Apple-signed or notarized, so right-click the application and choose **Open** the first time. You can also remove the quarantine attribute:
+
+```bash
+xattr -dr com.apple.quarantine /path/to/CodexLocalProxy-macos-arm64.app
+```
+
+### 4. Check providers
+
+Open the Codex control panel and confirm that providers are listed. On first launch, Codex providers are imported from CC Switch into a separate local catalog.
+
+Then open the Claude Code control panel. Claude Code providers continue to come directly from the current CC Switch data source. Records with an incompatible protocol or missing credentials are shown but cannot be selected.
+
+### 5. Configure clients
+
+In the two control panels, use **Copy Codex config** and **Copy Claude config**, then follow the next two sections to connect each client once. Future provider switches do not require client configuration changes.
+
+## Recommended with CC Switch
+
+CC Switch centrally maintains providers. Codex Provider Hub handles local forwarding, switching, retries, and statistics. Their responsibilities are:
+
+- **Codex:** when the local catalog is empty, providers are imported from CC Switch. Codex Provider Hub manages the imported copy independently, and browser edits do not write back to CC Switch.
+- **Claude Code:** providers continue to be read from CC Switch. Edit Claude providers in CC Switch, then refresh the Claude Code control panel.
+- **Import Codex again:** open **Providers**, select **Manage**, choose **Add new only** or **Overwrite existing**, then select **Import CCS**.
+- **Add new only:** retain existing local providers and import only new CC Switch records.
+- **Overwrite existing:** replace local records that have the same ID. This also replaces any independent local edits to those records.
+
+You can add a small number of Codex providers directly in management mode. CC Switch remains the recommended way to maintain larger Codex and Claude Code provider catalogs.
+
+## Configure Codex
+
+### Copy from the control panel
+
+1. Open `http://127.0.0.1:17890/control/codex/`.
+2. Select **Copy Codex config** at the bottom of the page.
+3. Merge the copied snippet into `~/.codex/config.toml`.
+4. Restart Codex once after the first configuration.
+
+The default snippet is:
+
+```toml
+model_provider = "local_cc_switch"
+
+[model_providers.local_cc_switch]
+name = "CC Switch Local Proxy"
+base_url = "http://127.0.0.1:17890/v1"
+wire_api = "responses"
+requires_openai_auth = true
+```
+
+Codex now always connects to the local address. A provider selected in the browser is used immediately for new requests, without another `config.toml` change.
+
+### Temporarily bypass the local proxy
+
+**Copy temporary launch command** on a Codex provider row produces a one-time command that starts the Codex CLI with that provider directly, without changing `config.toml`. The command contains provider credentials. Treat it as a secret and do not place it in public scripts, issues, or shared terminal history.
+
+## Configure Claude Code
+
+### Copy from the control panel
+
+1. Open `http://127.0.0.1:17890/control/claude/`.
+2. Select **Copy Claude config** at the bottom of the page.
+3. Run the copied command in the terminal where you will start Claude Code.
+4. Start `claude` from the same terminal.
+
+Windows PowerShell example:
+
+```powershell
+$env:ANTHROPIC_BASE_URL = "http://127.0.0.1:17890"
+$env:ANTHROPIC_API_KEY = "local-claude-proxy"
+claude
+```
+
+macOS/Linux example:
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:17890"
+export ANTHROPIC_API_KEY="local-claude-proxy"
+claude
+```
+
+You can also merge the values into `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:17890",
+    "ANTHROPIC_API_KEY": "local-claude-proxy"
+  }
+}
+```
+
+Notes:
+
+- Do not append `/v1` to `ANTHROPIC_BASE_URL`. The application forwards Claude Code's `/v1/messages` path.
+- `local-claude-proxy` is a non-empty local placeholder, not the real upstream key.
+- Do not configure `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` as an empty string, or Claude Code may immediately ask you to log in.
+- The local proxy removes client authentication headers and applies credentials from the Claude provider currently selected in the browser.
+
+## Manage and switch providers
+
+### Everyday switching
+
+Select a provider in the provider list. A switch affects only subsequent requests. A stream that has already produced output is not interrupted or replayed.
+
+### Manage Codex providers
+
+Select **Manage** in the Codex control panel to:
+
+- Drag providers to reorder them.
+- Hide providers that are temporarily unused.
+- Add a local provider.
+- Edit the name, Base URL, API key, request headers, query parameters, and request transport.
+- Delete any provider that is not currently selected.
+- Import only new providers from CC Switch or overwrite existing ones.
+
+Saving provider edits refreshes routing immediately. Normal status APIs and pages never return complete stored keys.
+
+### Manage Claude Code providers
+
+Claude Code providers come from CC Switch. Maintain their endpoint, authentication, and protocol in CC Switch, then refresh the Claude Code control panel. Only providers compatible with the Anthropic Messages protocol and containing credentials can be selected.
+
+## Request transport
+
+This setting is under **Providers > Manage > Edit > Request transport** in the Codex control panel.
+
+- **Standard (`httpx`):** the default for normal providers. It preserves the original network behavior.
+- **Compatibility (`curl_cffi`):** for a provider where the same endpoint and key work directly in Codex but consistently return a Cloudflare HTML 403 through the local proxy.
+
+Enable compatibility transport only for providers that actually block the default client fingerprint. `curl_cffi` does not fix genuine authentication failures, exhausted quotas, or unavailable upstream model channels.
+
+Claude Code upstream requests always use `curl_cffi`, so the Claude control panel does not expose this option.
+
+## Retry, usage, and monitoring
+
+### Automatic retries
+
+- Connection failures, stream failures before the first output, and HTTP `429/500/502/503/504` responses can be retried automatically.
+- Claude Code also retries `408` and `529`.
+- Fixed delay, increasing delay, maximum delay, unlimited retries, and circuit breaking are supported.
+- The default behavior does not rotate providers automatically. If you manually switch the current provider while a retry is waiting, the next attempt that has not emitted output follows the newly selected provider.
+- Once output has reached the client, the request is not replayed through another provider. This avoids duplicate answers, tool calls, and charges.
+
+### Request and token usage
+
+- The Requests page shows active requests and the most recent 24 hours.
+- Token counts use upstream `usage` when available and fall back to a `tiktoken` estimate.
+- Today, last 24 hours, last 7 days, last 30 days, and custom time ranges are supported.
+- The local database does not store request or response bodies.
+
+### Remote monitoring
+
+Codex providers can be uploaded through a restricted SSH importer to an independent status service. **Monitor management** lists all monitored server configurations and supports reordering, immediate probes, and deletion. Server deployment templates are under `deploy/`, and the public example is `config/providers.example.toml`.
+
+Monitoring indicates endpoint availability only. It does not guarantee that the local catalog uses the same key or that a requested model is available for a local request.
+
+## Troubleshooting
+
+### Claude Code says `Not logged in · Please run /login`
+
+1. Start Claude Code from the same terminal where the local environment variables were configured.
+2. Confirm that `ANTHROPIC_BASE_URL` is `http://127.0.0.1:17890` without `/v1`.
+3. Confirm that `ANTHROPIC_API_KEY` is a non-empty placeholder and remove any empty `ANTHROPIC_AUTH_TOKEN`.
+4. Open the Claude Code control panel and confirm that the current provider can be selected and has credentials.
+
+### Cloudflare HTML 403
+
+If the error body contains `@font-face`, `cf-fonts`, or a Cloudflare page while the same key works directly in Codex, enable `curl_cffi` compatibility transport for that Codex provider only.
+
+### HTTP 401
+
+A 401 means the upstream rejected the authentication attached to the current request. Check the provider selected in the browser, the key stored in the local catalog, custom `Authorization` or `X-API-Key` headers, and the Base URL. A successful server-side monitor does not prove that the current local record uses the same credentials.
+
+### HTTP 503 or "no available channel for model"
+
+This is an upstream provider state. Switching between `httpx` and `curl_cffi` cannot fix a missing model, an empty provider group, exhausted quota, or provider maintenance. Manually switch to a provider that supports the model; the existing retry behavior will handle attempts that have not produced output.
+
+### The control panel does not open
+
+1. Check whether the application is still running in the system tray or menu bar.
+2. Open `http://127.0.0.1:17890/healthz`.
+3. Check whether another process is using port `17890`.
+4. Do not troubleshoot by terminating every process with the same name, because that can interrupt sessions currently using the local proxy.
+
+### Changes do not take effect
+
+- Confirm that you are running the latest Release, not an old temporary test build.
+- Select **Save** after editing a provider, and refresh the page if necessary.
+- Codex and Claude providers have independent current selections. Make sure you switch in the correct control panel.
+- After changing the port, exit and restart the application, then copy both client configurations again.
+- Restart Codex once after its initial configuration. Later provider switches do not require a restart.
+
+## Other installation methods
+
+### Intel macOS
+
+The current Release provides an Apple Silicon package only. On an Intel Mac, follow **Run from source** below.
+
+### Windows desktop shortcut
+
+After checking out the repository, install a shortcut for the current user:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\install_local_proxy_shortcut.ps1
+```
+
+### Run from source
+
+Python 3.11 or newer is required. With `uv`:
+
+```powershell
+uv venv --clear .venv
+uv pip install --python .venv\Scripts\python.exe -r requirements-status.txt
+uv run --python .venv\Scripts\python.exe local_proxy_app.py
+```
+
+macOS/Linux:
+
+```bash
+uv venv --clear .venv
+uv pip install --python .venv/bin/python -r requirements-status.txt
+uv run --python .venv/bin/python local_proxy_app.py
+```
+
+With a standard Python virtual environment on Windows:
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements-status.txt
+.\.venv\Scripts\python.exe local_proxy_app.py
+```
+
+Append `--open-browser` to open both control panels at startup.
+
+## Development and deployment
+
+### Provider probe tool
+
+```powershell
+.\.venv\Scripts\python.exe probe_codex_cc_switch.py --list-providers
+.\.venv\Scripts\python.exe probe_codex_cc_switch.py --current-only --json
+```
+
+### Status service
+
+Copy the example configuration:
+
+```bash
+cp config/providers.example.toml config/providers.toml
+```
+
+Run the worker once:
+
+```bash
+./.venv/bin/python -m provider_status.worker \
+  --config config/providers.toml \
+  --control-database var/control/manual-probes.sqlite3 \
+  --once
+```
+
+Start the status page:
+
+```bash
+./.venv/bin/python -m provider_status.web \
+  --database var/public/status.sqlite3 \
+  --control-database var/control/manual-probes.sqlite3 \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+Production systemd and Nginx templates are in `deploy/`. Example domains and providers are placeholders and are not ready for production use.
+
+### Project structure
+
+```text
+.
+├── local_proxy_app.py         Unified application entry point
+├── local_proxy/               Local proxy, protocols, provider catalogs, lifecycle
+├── proxy_static/              Shared Codex and Claude Code control panel
+├── probe_tools/               Provider probe tools
+├── provider_status/           Health worker, storage, and status page
+├── config/                    Public example configuration
+├── deploy/                    systemd and Nginx templates
+├── scripts/                   Build, shortcut, and repository policy scripts
+├── tests/                     Python, PowerShell, and JavaScript tests
+└── docs/                      Designs, change records, and detailed documentation
+```
+
+### Tests
+
+```powershell
+python -m unittest discover -s tests
+node --check proxy_static/app.js
+node --check provider_status/static/app.js
+Get-ChildItem tests -Filter *.test.js | ForEach-Object { node --test $_.FullName }
+```
+
+## Security boundaries
+
+- The local proxy can listen only on loopback addresses.
+- The CC Switch SQLite data source is opened read-only. Imported Codex providers are stored separately at `~/.codex-local-proxy/codex-providers.sqlite3`.
+- Normal status, statistics, and provider editing APIs never return complete upstream keys.
+- **Copy temporary launch command** writes the current Codex provider credentials to the clipboard. Treat the result as a secret.
+- Client authentication headers are removed before forwarding, then credentials for the current provider are applied.
+- Token statistics and request history do not store request or response bodies.
+- Private configuration, databases, logs, probe reports, virtual environments, certificates, and keys are excluded from version control by default.
+- `config/providers.example.toml` contains example domains only, with no real providers or credentials.
+
+## Open-source and commercial licensing
+
+Codex Provider Hub is licensed under the [GNU Affero General Public License v3.0 or later](LICENSE), with SPDX identifier `AGPL-3.0-or-later`.
+
+- Individuals and organizations may use, copy, modify, and distribute this project, including in commercial environments.
+- Distribution or provision of a modified network service must satisfy the corresponding AGPL source, license, and copyright obligations.
+- Derivative development and redistribution must retain the copyright notice and original project attribution in [NOTICE](NOTICE).
+- A [proprietary commercial license](COMMERCIAL-LICENSE.md) is required if you want to distribute a closed-source version, provide a modified closed-source network service, or integrate the code into a proprietary product that cannot comply with the AGPL.
+- Commercial use that fully complies with the AGPL does not require purchasing a commercial license.
+
+The commercial licensing document is not itself a commercial license agreement. Follow its contact process and execute a separate agreement with the maintainers.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codex Provider Hub
 
+[简体中文](README.md) | [English](README.en.md)
+
 <div align="center">
 
 在一个本地程序中管理 Codex 与 Claude Code 的多个 API 供应商，支持网页切换、失败重试、请求记录、Token 统计和远程健康监控。

--- a/docs/changes/2026-08-21-v1-bilingual-readme-about.md
+++ b/docs/changes/2026-08-21-v1-bilingual-readme-about.md
@@ -1,0 +1,68 @@
++++
+id = "2026-08-21-v1-bilingual-readme-about"
+type = "docs"
+release_bump = "major"
+status = "verified"
++++
+
+# v1 双语 README 与仓库定位
+
+## 目标
+
+为 Codex Provider Hub 提供内容完整、可互相切换的简体中文和英文 README，并更新 GitHub About 与 Topics，使仓库公开定位准确覆盖 Codex、Claude Code、CC Switch 和本地多供应商路由能力；合入后发布首个稳定主版本 `v1.0.0`。
+
+## 现状
+
+仓库只有简体中文 README，国际用户缺少完整使用教程。GitHub About 仍将项目描述为单一 Codex 代理，没有体现 Claude Code、CC Switch、双控制台、供应商切换和健康监控等当前能力，Topics 为空。
+
+## 设计范围
+
+- `README.md` 保持简体中文主入口，并在顶部增加语言切换。
+- 新增完整 `README.en.md`，对应中文版的用户范围、快速开始、客户端配置、供应商管理、传输方式、重试统计、远程监控、故障排查、开发部署、安全和授权说明。
+- 增加文档契约测试，校验双语入口、关键章节、控制台地址、下载地址、CC Switch、传输兼容方式和授权边界。
+- GitHub About 使用中英双语的一句话重新描述产品定位。
+- GitHub Topics 增加 Codex、Claude Code、CC Switch、本地代理、供应商路由、API 网关、FastAPI 和健康监控相关主题。
+- 使用 `release_bump = "major"` 触发从 `v0.13.3` 到 `v1.0.0` 的自动发布。
+
+## 非目标
+
+- 不修改应用运行时、控制台界面、接口、配置格式、安装包名称或网络行为。
+- 不修改仓库名称、主页地址、许可证或商业授权条款。
+- 不手工创建或推送 Git Tag。
+
+## 兼容性
+
+仅修改公开文档、文档测试和 GitHub 仓库元数据，无运行时、客户端、数据库、配置或迁移影响。现有中文 README 链接继续有效，英文用户可使用新增的独立入口。
+
+## 风险
+
+主要风险是双语内容不同步或英文教程遗漏关键安全与授权边界。通过文档契约测试锁定两份 README 的共同关键内容，并保持章节结构对应。GitHub About 与 Topics 在 PR 合入后通过 API 回读验证。
+
+## 测试计划
+
+- 先新增双语 README 契约测试，确认在英文版不存在时按预期失败。
+- 运行文档契约测试，确认双语入口和关键内容全部通过。
+- 检查两份 README 的 Markdown 本地链接和公开下载链接。
+- 运行完整 Python 测试、JavaScript 语法检查、JavaScript 测试、仓库策略检查和 `git diff --check`。
+- PR 合入后回读 GitHub About、Topics，并确认自动发布版本和 Windows/macOS 资产。
+
+## 实际改动
+
+- `README.md` 顶部增加简体中文与英文切换入口，原有中文教程和链接保持不变。
+- 新增 `README.en.md`，完整对应中文教程的 13 个主章节，保留相同的命令、配置、下载资产、端口、安全和授权边界。
+- `tests/test_project_documentation.py` 增加双语入口与英文教程契约测试，锁定两套控制台地址、CC Switch、`curl_cffi`、下载资产和授权说明。
+- GitHub About 与 Topics 将在 PR 合入后更新并通过 API 回读验证。
+
+## 验证结果
+
+- TDD RED：首次运行 `python -m unittest tests.test_project_documentation`，6 项中 2 项按预期因 `README.en.md` 不存在而失败。
+- TDD GREEN：实现双语 README 后运行 `python -m unittest tests.test_project_documentation`，6 项全部通过。
+- `python -m unittest discover -s tests -p "test_*.py"`：482 项全部通过。
+- `node --check proxy_static/app.js` 与 `node --check provider_status/static/app.js`：全部通过。
+- `Get-ChildItem tests -Filter *.test.js | ForEach-Object { node --test $_.FullName }`：全部 JavaScript 测试通过。
+- 两份 README 各有 13 个主内容章节、27 个 Markdown 链接和 5 个本地链接，本地链接无缺失。
+- `git diff --check`：通过。
+
+## PR
+
+pending

--- a/tests/test_project_documentation.py
+++ b/tests/test_project_documentation.py
@@ -63,6 +63,57 @@ class ProjectDocumentationTests(unittest.TestCase):
         self.assertNotIn("当前仓库尚未附带开源许可证", readme)
         self.assertNotIn("所有商业使用都必须付费", readme)
 
+    def test_readmes_offer_language_switching(self) -> None:
+        language_switch = "[简体中文](README.md) | [English](README.en.md)"
+        english_path = ROOT / "README.en.md"
+        self.assertTrue(english_path.is_file(), "README.en.md must exist")
+        chinese_readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        english_readme = english_path.read_text(encoding="utf-8")
+
+        self.assertIn(language_switch, chinese_readme)
+        self.assertIn(language_switch, english_readme)
+
+    def test_english_readme_is_a_complete_user_guide(self) -> None:
+        english_path = ROOT / "README.en.md"
+        self.assertTrue(english_path.is_file(), "README.en.md must exist")
+        readme = english_path.read_text(encoding="utf-8")
+        required_sections = (
+            "## Who this is for",
+            "## Five-minute quick start",
+            "## Recommended with CC Switch",
+            "## Configure Codex",
+            "## Configure Claude Code",
+            "## Manage and switch providers",
+            "## Request transport",
+            "## Retry, usage, and monitoring",
+            "## Troubleshooting",
+            "## Other installation methods",
+            "## Development and deployment",
+            "## Security boundaries",
+            "## Open-source and commercial licensing",
+        )
+
+        for section in required_sections:
+            with self.subTest(section=section):
+                self.assertIn(section, readme)
+
+        shared_references = (
+            "https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-win-x64.exe",
+            "https://github.com/AI-Routing-Research-Institute/codex-provider-hub/releases/latest/download/CodexLocalProxy-macos-arm64.zip",
+            "http://127.0.0.1:17890/control/codex/",
+            "http://127.0.0.1:17890/control/claude/",
+            "CC Switch",
+            "curl_cffi",
+            "AGPL-3.0-or-later",
+            "COMMERCIAL-LICENSE.md",
+        )
+
+        for reference in shared_references:
+            with self.subTest(reference=reference):
+                self.assertIn(reference, readme)
+
+        self.assertNotIn("all commercial use requires payment", readme.lower())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 功能修改

- 中文 README 增加语言切换入口。
- 新增完整英文 README，覆盖安装、配置、切换、重试、监控、故障排查、安全和授权。
- 新增双语文档契约测试。
- 使用 major 变更记录触发 v1.0.0 自动发布。

## 影响范围

仅公开文档、文档测试和 GitHub 元数据，无运行时兼容性影响。

## 风险

主要风险为双语内容不同步；契约测试锁定共同关键章节、链接和安全授权边界。

## 验证结果

- Python：482 项通过
- JavaScript：语法检查及全部测试通过
- 仓库策略、Markdown 本地链接、git diff 检查通过

精确 head SHA：`030d522a503cdabf7578b857ed56c605bd907ebe`