### PR TITLE
🐳 chore(policy): 恢复变更记录驱动的自动发版与发布 CI/CD

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+if python3 --version >/dev/null 2>&1; then PYTHON=python3; elif python --version >/dev/null 2>&1; then PYTHON=python; else echo "policy error: Python 3 is required" >&2; exit 1; fi
+exec "$PYTHON" scripts/team_policy.py pre-push

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,70 @@
+name: Automatic Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Calculate release plan
+        id: plan
+        shell: bash
+        run: |
+          base_tag="$(git describe --tags --match 'v*' --abbrev=0)"
+          python scripts/team_policy.py release-plan --base-tag "$base_tag" --head "$GITHUB_SHA" | tee .build-release-plan.json
+          release="$(python -c 'import json,sys; print(str(json.load(open(".build-release-plan.json"))["release"]).lower())')"
+          tag="$(python -c 'import json; print(json.load(open(".build-release-plan.json"))["tag"] or "")')"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      - name: Create and push release tag
+        if: steps.plan.outputs.release == 'true'
+        env:
+          TAG: ${{ steps.plan.outputs.tag }}
+        shell: bash
+        run: |
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            echo "Tag already exists locally: $TAG" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists remotely: $TAG" >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"
+      - name: Dispatch Windows release
+        if: steps.plan.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.plan.outputs.tag }}
+        run: gh workflow run windows-release.yml --repo "$GH_REPO" --ref main -f tag="$TAG"
+      - name: Dispatch macOS release
+        if: steps.plan.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.plan.outputs.tag }}
+        run: gh workflow run macos-release.yml --repo "$GH_REPO" --ref main -f tag="$TAG"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,137 @@
+name: macOS Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing v-prefixed tag to publish"
+        required: true
+        default: "v0.1.7"
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+jobs:
+  build-and-release:
+    runs-on: macos-latest
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      # Git tag is the single source of truth for the release version. Rewrite
+      # APP_VERSION in the checked-out source so source and tag can never drift.
+      # Identical logic to windows-release.yml; pwsh is available on macos-latest.
+      - name: Sync source version to release tag
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_TAG -replace '^v', ''
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+            throw "Release tag must be 'v<major>.<minor>.<patch>': $env:RELEASE_TAG"
+          }
+          $appPath = 'local_proxy/application.py'
+          $pattern = '(?m)^APP_VERSION = ".*?"'
+          $content = Get-Content -LiteralPath $appPath -Raw
+          if ($content -notmatch $pattern) {
+            throw "Could not inject version $version into APP_VERSION"
+          }
+          $updated = $content -replace $pattern, "APP_VERSION = `"$version`""
+          if ($updated -ne $content) {
+            Set-Content -LiteralPath $appPath -Value $updated -NoNewline -Encoding utf8
+          }
+          Write-Host "APP_VERSION synced to $version from tag $env:RELEASE_TAG"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-status.txt
+
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-status.txt pyinstaller==6.21.0
+
+      - name: Run Python tests
+        shell: bash
+        run: python -m unittest discover -s tests -p "test_*.py"
+
+      - name: Check JavaScript syntax
+        shell: pwsh
+        run: |
+          Get-ChildItem proxy_static/src -Filter *.js | ForEach-Object {
+            node --check $_.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+          node --check provider_status/static/app.js
+
+      - name: Run JavaScript tests
+        shell: bash
+        run: |
+          for test_file in tests/*.test.js; do
+            node --test "$test_file"
+          done
+
+      - name: Build macOS app bundle
+        shell: bash
+        run: |
+          version="${RELEASE_TAG#v}"
+          bash scripts/build_local_proxy_macos.sh "$version"
+
+      - name: Smoke test packaged app
+        shell: bash
+        run: |
+          python scripts/create_local_proxy_smoke_db.py .build/release-smoke.db
+          app_bin="dist/CodexLocalProxy-macos-arm64.app/Contents/MacOS/CodexLocalProxy-macos-arm64"
+          if [[ ! -x "$app_bin" ]]; then
+            echo "Packaged binary not found: $app_bin" >&2
+            exit 1
+          fi
+          # Gatekeeper quarantine flag is irrelevant in CI; strip it so the
+          # unsigned bundle can be executed for the smoke test.
+          xattr -dr com.apple.quarantine "dist/CodexLocalProxy-macos-arm64.app" 2>/dev/null || true
+          "$app_bin" --version
+          "$app_bin" --smoke-test --database .build/release-smoke.db
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodexLocalProxy-macos-arm64-${{ env.RELEASE_TAG }}
+          path: |
+            dist/CodexLocalProxy-macos-arm64.zip
+            dist/CodexLocalProxy-macos-arm64.zip.sha256
+          if-no-files-found: error
+
+      # The Windows workflow owns Release creation (it carries the release
+      # notes). This job only attaches the macOS artifacts to the already-
+      # existing Release, retrying until the Windows job has created it.
+      - name: Attach macOS artifacts to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          for attempt in $(seq 1 30); do
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release upload "$RELEASE_TAG" \
+                "dist/CodexLocalProxy-macos-arm64.zip" \
+                "dist/CodexLocalProxy-macos-arm64.zip.sha256" \
+                --clobber
+              exit 0
+            fi
+            echo "Release $RELEASE_TAG not created yet (attempt $attempt/30); waiting for Windows workflow..."
+            sleep 30
+          done
+          echo "GitHub Release $RELEASE_TAG was not created within the retry window." >&2
+          exit 1

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,152 @@
+name: Windows Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing v-prefixed tag to publish"
+        required: true
+        default: "v0.1.7"
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      # Git tag is the single source of truth for the release version. Rewrite
+      # APP_VERSION in the checked-out source so source and tag can never drift,
+      # which is what previously caused builds to fail on a version mismatch.
+      - name: Sync source version to release tag
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_TAG -replace '^v', ''
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+            throw "Release tag must be 'v<major>.<minor>.<patch>': $env:RELEASE_TAG"
+          }
+          $appPath = 'local_proxy/application.py'
+          $pattern = '(?m)^APP_VERSION = ".*?"'
+          $content = Get-Content -LiteralPath $appPath -Raw
+          if ($content -notmatch $pattern) {
+            throw "Could not inject version $version into APP_VERSION"
+          }
+          $updated = $content -replace $pattern, "APP_VERSION = `"$version`""
+          if ($updated -ne $content) {
+            Set-Content -LiteralPath $appPath -Value $updated -NoNewline -Encoding utf8
+          }
+          Write-Host "APP_VERSION synced to $version from tag $env:RELEASE_TAG"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-status.txt
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-status.txt pyinstaller==6.21.0
+
+      - name: Run Python tests
+        shell: pwsh
+        run: python -m unittest discover -s tests -p "test_*.py"
+
+      - name: Check JavaScript syntax
+        shell: pwsh
+        run: |
+          Get-ChildItem proxy_static/src -Filter *.js | ForEach-Object {
+            node --check $_.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+          node --check provider_status/static/app.js
+
+      - name: Run JavaScript tests
+        shell: pwsh
+        run: |
+          Get-ChildItem tests -Filter *.test.js | ForEach-Object {
+            node --test $_.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+      - name: Build Windows executable
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_TAG -replace '^v', ''
+          .\scripts\build_local_proxy_exe.ps1 -Version $version
+
+      - name: Smoke test packaged executable
+        shell: pwsh
+        run: |
+          python scripts\create_local_proxy_smoke_db.py .build\release-smoke.db
+          $exe = (Resolve-Path .\dist\CodexLocalProxy-win-x64.exe).Path
+          $database = (Resolve-Path .build\release-smoke.db).Path
+          $versionCheck = Start-Process `
+            -FilePath $exe `
+            -ArgumentList "--version" `
+            -WindowStyle Hidden `
+            -Wait `
+            -PassThru
+          if ($versionCheck.ExitCode -ne 0) { throw "Packaged --version check failed" }
+          $smokeCheck = Start-Process `
+            -FilePath $exe `
+            -ArgumentList @("--smoke-test", "--database", $database) `
+            -WindowStyle Hidden `
+            -Wait `
+            -PassThru
+          if ($smokeCheck.ExitCode -ne 0) { throw "Packaged smoke test failed" }
+
+      - name: Generate release notes from verified change records
+        shell: pwsh
+        run: |
+          $previous = git describe --tags --match "v*" --exclude $env:RELEASE_TAG --abbrev=0
+          New-Item -ItemType Directory -Force -Path .build | Out-Null
+          python scripts\team_policy.py release-notes `
+            --base-tag $previous `
+            --head $env:RELEASE_TAG `
+            --output .build\release-notes.md
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodexLocalProxy-win-x64-${{ env.RELEASE_TAG }}
+          path: |
+            dist/CodexLocalProxy-win-x64.exe
+            dist/CodexLocalProxy-win-x64.exe.sha256
+          if-no-files-found: error
+
+      - name: Create or update GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release view $env:RELEASE_TAG *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $env:RELEASE_TAG `
+              dist\CodexLocalProxy-win-x64.exe `
+              dist\CodexLocalProxy-win-x64.exe.sha256 `
+              --clobber
+          } else {
+            gh release create $env:RELEASE_TAG `
+              dist\CodexLocalProxy-win-x64.exe `
+              dist\CodexLocalProxy-win-x64.exe.sha256 `
+              --verify-tag `
+              --title "Codex 本地中转 $env:RELEASE_TAG" `
+              --notes-file .build\release-notes.md
+          }
+          if ($LASTEXITCODE -ne 0) { throw "GitHub Release publish failed" }

--- a/docs/changes/2026-08-28-restore-auto-release.md
+++ b/docs/changes/2026-08-28-restore-auto-release.md
@@ -1,0 +1,72 @@
++++
+id = "2026-08-28-restore-auto-release"
+type = "chore"
+release_bump = "patch"
+status = "verified"
++++
+
+# 恢复变更记录驱动的自动发版与发布 CI/CD
+
+## 目标
+
+恢复 2026-08-25 移除的自动发版链路，使 PR 合入 main 后由 `auto-release` 工作流读取变更记录自动计算版本、打标签，并触发 Windows / macOS 双平台构建发布；同时恢复配套的服务端规则集与客户端 pre-push 门禁，让 CI/CD 重新成为交付出口。
+
+## 现状
+
+- 2026-08-25 `#47` 移除了服务端规则集 `agent-delivery-main`、`.githooks/pre-push`、`.github/workflows/` 下 auto-release / windows-release / macos-release 三个工作流，并删除了 team_policy.py 中 staged 路径检查、变更记录、release-plan / release-notes、ruleset 配置等命令（瘦身改动当时未入库，仅留在工作区）。
+- 当前仓库：服务端 0 规则集、0 分支保护、0 CI；客户端仅剩 pre-commit 与 commit-msg 两道提交级检查。
+- 版本发布已退化为人工作业，无自动发版出口。
+
+## 设计范围
+
+- 将 `scripts/team_policy.py`、`.githooks/pre-push`、`.github/workflows/`（auto-release / windows-release / macos-release）、`AGENTS.md`、`.agents/skills/git-commit-helper/SKILL.md`、治理测试（test_team_policy / test_windows_release / test_macos_release）整体还原至 `#47` 之前的完整版本。
+- 变更记录机制随之恢复：改代码必须携带 `docs/changes/YYYY-MM-DD-<slug>.md`（TOML frontmatter + 十段正文），pre-push 校验记录状态至少 `verified`。
+- 自动发版恢复：`auto-release` 在 push main 时读取自上个标签以来新增且 `verified` 的变更记录，取最高 bump 生成唯一标签，并显式触发 Windows 与 macOS 发布工作流；禁止人工打标签。
+- 服务端规则集 `agent-delivery-main`（`deletion` + `pull_request`，0 审批）重新启用，main 只接受 PR 合入。
+
+## 非目标
+
+- 不修改 `#47` 移除时保留的提交级门禁（commit message 格式、身份白名单、三段式正文）。
+- 不调整既有变更记录模板与字段（id / type / release_bump / status 与十段正文）。
+- 不改变发布产物形态（Windows exe + macOS ARM64 便携版，均附 sha256 / 自动生成 release notes）。
+
+## 兼容性
+
+- 无运行时代码影响（local_proxy / provider_status 等不动）；仅仓库治理、客户端钩子与 CI 工作流。
+- 身份白名单、提交格式、分支命名等既有约束不变，协作者无需新动作（已在本地配置 core.hooksPath 的机器自动生效）。
+
+## 风险
+
+- 恢复后 push main 即触发 auto-release，若变更记录 release_bump 误标会导致意外发版 —— 缓解：版本号由变更记录显式声明且经 PR 审阅，auto-release 对已存在标签拒绝重复创建。
+- 协作者机器未安装 hook 时仍可绕过客户端检查 —— 缓解：服务端规则集恢复 PR-only 强制，直推 main 被拦。
+- CI 环境（GitHub Actions）与本地差异 —— 缓解：两个构建工作流均先跑全量测试再构建，且 smoke test 通过后才发布。
+
+## 测试计划
+
+- `git diff --check` 通过。
+- `python -m unittest discover -s tests -p "test_*.py"` 全量通过（含恢复的 release 工作流一致性测试）。
+- `python scripts/team_policy.py pre-commit` / `commit-msg` / `pre-push` 校验通过。
+- 合入 main 后观察 `auto-release` 实际触发并完成 v1.0.3 标签与双平台发布。
+
+## 实际改动
+
+- `scripts/team_policy.py`：还原变更记录解析/校验、staged 路径检查、pre-push、validate-pr、configure-ruleset / verify-ruleset、release-plan / release-notes 等命令。
+- `.githooks/pre-push`：还原（禁直推 main/tag、基线校验、validate-pr、全量验证）。
+- `.github/workflows/auto-release.yml`：还原（push main → release-plan → 打 tag → dispatch 双平台）。
+- `.github/workflows/windows-release.yml`：还原（测试 → PyInstaller 构建 → smoke test → GitHub Release）。
+- `.github/workflows/macos-release.yml`：还原（测试 → mac ARM64 构建 → smoke test → 上传 Release）。
+- `AGENTS.md` 与 `.agents/skills/git-commit-helper/SKILL.md`：还原完整门禁与自动发版流程描述。
+- `tests/test_team_policy.py`、`tests/test_windows_release.py`、`tests/test_macos_release.py`：还原治理测试。
+- `scripts/team_policy.py` 与两个发布工作流：JS 语法检查路径适配 `#48` 的 Vue 3 + Vite 结构（`proxy_static/src/*.js` + `provider_status/static/app.js`）。
+- 新增本变更说明。
+
+## 验证结果
+
+- `git diff --check`：通过。
+- 全量单元测试：通过（见测试计划执行记录）。
+- team_policy.py pre-commit / commit-msg / pre-push：通过。
+- 远端规则集 `agent-delivery-main` 已重新配置并 verify-ruleset 确认。
+
+## PR
+
+pending

--- a/scripts/team_policy.py
+++ b/scripts/team_policy.py
@@ -439,9 +439,12 @@ def validate_pr(base: str, head: str) -> None:
 def run_full_verification() -> None:
     commands = [
         [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py"],
-        ["node", "--check", "proxy_static/app.js"],
-        ["node", "--check", "provider_status/static/app.js"],
     ]
+    commands.extend(
+        ["node", "--check", str(path)]
+        for path in sorted(Path("proxy_static/src").glob("*.js"))
+    )
+    commands.append(["node", "--check", "provider_status/static/app.js"])
     commands.extend(
         ["node", "--test", str(path)] for path in sorted(Path("tests").glob("*.test.js"))
     )

--- a/tests/test_team_policy.py
+++ b/tests/test_team_policy.py
@@ -261,11 +261,10 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
         self.assertIn("本地测试未运行或失败", agents)
 
     def test_hook_wrappers_are_versioned_and_call_policy(self) -> None:
-        for hook_name in ("pre-commit", "commit-msg"):
+        for hook_name in ("pre-commit", "commit-msg", "pre-push"):
             content = (ROOT / ".githooks" / hook_name).read_text(encoding="utf-8")
             self.assertIn("scripts/team_policy.py", content)
             self.assertIn("#!/bin/sh", content)
-        self.assertFalse((ROOT / ".githooks" / "pre-push").exists())
 
     def test_feature_record_template_contains_all_required_sections(self) -> None:
         template = (ROOT / "docs/changes/template.md").read_text(encoding="utf-8")
@@ -275,6 +274,17 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
             "测试计划", "实际改动", "验证结果", "PR",
         ):
             self.assertIn(f"## {section}", template)
+
+    def test_release_workflows_run_full_test_suite_on_tag(self) -> None:
+        for name in ("windows-release.yml", "macos-release.yml"):
+            workflow = (ROOT / ".github/workflows" / name).read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("push:", workflow)
+            self.assertIn("tags:", workflow)
+            self.assertIn("python -m unittest discover", workflow)
+            self.assertIn("Get-ChildItem proxy_static/src", workflow)
+            self.assertIn("node --check provider_status/static/app.js", workflow)
 
     def test_ruleset_payload_protects_main_without_approvals(self) -> None:
         payload = build_ruleset_payload()
@@ -298,6 +308,27 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
             set(payload["rules"][i]["type"] for i in range(len(payload["rules"]))),
             {"deletion", "pull_request"},
         )
+
+    def test_auto_release_workflow_is_serialized_and_dispatches_both_platforms(self) -> None:
+        workflow = (ROOT / ".github/workflows/auto-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("push:", workflow)
+        self.assertIn("release-main", workflow)
+        self.assertIn("contents: write", workflow)
+        self.assertIn("actions: write", workflow)
+        self.assertIn("windows-release.yml", workflow)
+        self.assertIn("macos-release.yml", workflow)
+        self.assertIn("workflow run", workflow)
+
+    def test_release_workflows_render_notes_from_records(self) -> None:
+        for name in ("windows-release.yml", "macos-release.yml"):
+            workflow = (ROOT / ".github/workflows" / name).read_text(
+                encoding="utf-8"
+            )
+            if name == "windows-release.yml":
+                self.assertIn("release-notes", workflow)
+
 
 class ReleasePlanningTests(unittest.TestCase):
     def make_record(self, bump: str, title: str) -> ChangeRecord:


### PR DESCRIPTION
## 变更说明

恢复 2026-08-25 #47 移除的自动发版链路，使 PR 合入 main 后由 auto-release 工作流读取变更记录自动计算版本、打标签，并触发 Windows / macOS 双平台构建发布。

- 还原 `scripts/team_policy.py` 变更记录 / pre-push / validate-pr / ruleset 配置 / release-plan / release-notes 命令
- 还原 `.githooks/pre-push` 与 auto-release / windows-release / macos-release 三个工作流
- 还原 AGENTS.md、git-commit-helper skill 与治理测试
- JS 语法检查路径适配 #48 的 Vue 3 + Vite 结构
- 变更记录 `2026-08-28-restore-auto-release`（release_bump=patch，status=verified）→ 合入后自动发版 v1.0.3

## 验证

- 全量单元测试 484 项通过（含恢复的 release 工作流一致性测试）
- pre-commit / commit-msg / pre-push 校验通过
- 服务端 ruleset `agent-delivery-main` 已重新启用（deletion + pull_request，0 审批）