### PR TITLE
🐞 fix(proxy): 支持 HTTP 402 按策略重试

### DIFF
--- a/docs/changes/2026-08-31-infinite-http-402-retry.md
+++ b/docs/changes/2026-08-31-infinite-http-402-retry.md
@@ -1,0 +1,66 @@
++++
+id = "2026-08-31-infinite-http-402-retry"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# HTTP 402 重试策略
+
+## 目标
+
+将上游 HTTP 402 纳入现有供应商重试机制，使预算池临时耗尽后可以按照当前重试配置继续等待恢复；在无限重试模式下，402 请求持续重试，直到请求成功或客户端断开。
+
+## 现状
+
+本地中转当前只将 403、500、502、503、504 和 429 识别为可重试状态。Agent Router 返回“Budget pool quota has been exhausted”的 HTTP 402 会直接结束请求，导致配置为无限重试的请求无法等待额度恢复。
+
+## 设计范围
+
+- 将 HTTP 402 映射为 `http_402`，接入已有重试循环、活动请求状态和恢复记录。
+- 保持现有 RetryPolicy 语义：启用且 `max_attempts = -1` 时无限重试，有限次数时遵守配置，关闭时直接返回 402。
+- 重试前继续刷新当前供应商，使用户切换供应商后后续尝试可以使用新的供应商。
+- 复用已有错误正文提取和脱敏逻辑，保存并显示 402 的上游错误摘要。
+- 客户端断开时停止重试并完成请求清理。
+
+## 非目标
+
+- 不改变 HTTP 401、403 或其他状态码的现有重试策略。
+- 不修改供应商额度、预算池或认证配置。
+- 不新增独立的 402 专用配置项或后台任务。
+
+## 兼容性
+
+现有配置格式和数据库结构无需迁移；只有已经启用重试的请求会受到影响。该改动修复现有重试策略遗漏的上游状态，版本选择 `patch`。
+
+## 风险
+
+预算池耗尽可能长期不恢复，无限重试会保持请求活动并继续消耗重试请求。实现复用现有退避、客户端断开清理和状态展示，测试有限次数、无限次数及断开场景，避免影响其他请求。
+
+## 测试计划
+
+- 验证 HTTP 402 被识别为 `http_402`。
+- 验证有限次数策略在 402 后按配置次数停止，并保留错误摘要。
+- 验证无限次数策略在 402 后继续重试，供应商恢复后请求成功。
+- 验证重试过程中切换当前供应商后使用新的供应商。
+- 验证客户端断开后无限重试停止、活动请求清理且恢复记录完整。
+- 运行完整 Python 单测、JavaScript 语法检查、JavaScript 测试、Python 编译与差异检查。
+
+## 实际改动
+
+- `local_proxy/core.py` 将 HTTP 402 加入统一可重试状态集合，使其遵循现有 RetryPolicy 的有限或无限重试配置。
+- `tests/test_proxy_core.py` 覆盖 402 错误摘要、有限重试和无限重试恢复场景。
+
+## 验证结果
+
+- `C:\code\codex_provider_probe\.venv\Scripts\python.exe -m unittest tests.test_proxy_core.ProxyAppTests.test_http_402_is_retried_with_upstream_error_summary tests.test_proxy_core.ProxyAppTests.test_http_402_retries_indefinitely_until_provider_recovers`：通过，2 项测试。
+- `C:\code\codex_provider_probe\.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"`：通过，508 项测试，耗时 70.318 秒。
+- `Get-ChildItem -Path proxy_static/src,provider_status/static,tests -File -Filter *.js | ForEach-Object { node --check $_.FullName }`：通过。
+- `Get-ChildItem -Path tests -File -Filter *.test.js | ForEach-Object { node --test $_.FullName }`：通过，全部 JavaScript 测试文件通过。
+- `C:\code\codex_provider_probe\.venv\Scripts\python.exe -m compileall -q provider_status local_proxy scripts tests`：通过。
+- `npm run build --prefix proxy_static`：通过，Vite 转换 26 个模块；构建产物仅用于验证，未纳入提交。
+- `git diff --check`：通过。
+
+## PR
+
+pending

--- a/docs/changes/2026-08-31-infinite-http-402-retry.md
+++ b/docs/changes/2026-08-31-infinite-http-402-retry.md
@@ -63,4 +63,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/55

--- a/local_proxy/core.py
+++ b/local_proxy/core.py
@@ -87,7 +87,7 @@ REQUEST_HEADERS_TO_REPLACE = HOP_BY_HOP_HEADERS | {
 CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
 MAX_CODEX_TURN_METADATA_CHARS = 32 * 1024
 RESPONSE_HEADERS_TO_DROP = HOP_BY_HOP_HEADERS | {"content-length"}
-RETRYABLE_STATUS_CODES = {403, 500, 502, 503, 504}
+RETRYABLE_STATUS_CODES = {402, 403, 500, 502, 503, 504}
 SENSITIVE_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(authorization|api[-_ ]?key|access[-_ ]?token|token|secret)\b"
     r"[\"']?(\s*[:=]\s*)[\"']?(?:bearer\s+)?[^\s,;\"'}]+[\"']?"

--- a/tests/test_proxy_core.py
+++ b/tests/test_proxy_core.py
@@ -2366,6 +2366,83 @@ class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(router.status().total_retries, 1)
         self.assertEqual(router.status().last_error, "http_403")
 
+    async def test_http_402_is_retried_with_upstream_error_summary(self) -> None:
+        attempts = 0
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                return httpx.Response(
+                    402,
+                    headers={"content-type": "application/json"},
+                    content=json.dumps(
+                        {
+                            "error": {
+                                "message": "Budget pool quota has been exhausted"
+                            }
+                        }
+                    ).encode(),
+                )
+            return httpx.Response(200, content=b"recovered")
+
+        router = ProviderRouter((provider("selected", current=True),))
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            router,
+            client=upstream_client,
+            retry_policy=RetryPolicy(max_attempts=2),
+            retry_sleep=lambda _: _empty_wait(),
+        )
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post("/v1/responses", json={"model": "test"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"recovered")
+        self.assertEqual(attempts, 2)
+        status = router.status()
+        self.assertEqual(status.last_retry_kind, "http_402")
+        self.assertIn(
+            "Budget pool quota has been exhausted",
+            status.recent_retry_errors[0].summary,
+        )
+
+    async def test_http_402_retries_indefinitely_until_provider_recovers(self) -> None:
+        attempts = 0
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
+            if attempts <= 5:
+                return httpx.Response(402, content=b"quota exhausted")
+            return httpx.Response(200, content=b"recovered")
+
+        router = ProviderRouter((provider("selected", current=True),))
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        app = create_proxy_app(
+            router,
+            client=upstream_client,
+            retry_policy=RetryPolicy(max_attempts=-1),
+            retry_sleep=lambda _: _empty_wait(),
+        )
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        )
+        self.addAsyncCleanup(client.aclose)
+        self.addAsyncCleanup(upstream_client.aclose)
+
+        response = await client.post("/v1/responses", json={"model": "test"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"recovered")
+        self.assertEqual(attempts, 6)
+        self.assertEqual(router.status().total_retries, 5)
+
     async def test_retry_policy_control_api_validates_updates_and_hides_secrets(self) -> None:
         changed: list[RetryPolicy] = []
         store = RetryPolicyStore()


### PR DESCRIPTION
## 变更说明

- 将 HTTP 402 纳入本地 Codex 中转的统一重试状态。
- 402 遵循现有 RetryPolicy：max_attempts = -1 时无限重试，有限值时按配置执行。
- 保留当前供应商刷新、错误摘要脱敏和客户端断开清理逻辑。
- 变更记录：docs/changes/2026-08-31-infinite-http-402-retry.md

## 风险

预算池长期耗尽时，无限重试会保持请求活动；用户可通过关闭重试或调整最大次数停止等待。

## 验证

- Python 全量单测：508 项通过。
- JavaScript 语法检查和测试：通过。
- Python compileall：通过。
- Vite production build：26 个模块通过。
- git diff --check：通过。

PR 阶段按仓库规则不运行 CI。