### PR TITLE
🐞 fix(proxy): 修复请求历史窗口与流式请求清理

### DIFF
--- a/docs/changes/2026-08-31-request-history-seven-day-window.md
+++ b/docs/changes/2026-08-31-request-history-seven-day-window.md
@@ -1,0 +1,56 @@
++++
+id = "2026-08-31-request-history-seven-day-window"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 修复请求记录近七天查询范围
+
+## 目标
+
+让请求记录页面的“近 7 天”筛选按完整 168 小时查询，正确返回保留范围内的历史记录。
+
+## 现状
+
+请求历史查询将 `7d` 映射为 7 小时，导致页面选择“近 7 天”时只显示最近 7 小时的记录。数据库保留与清理仍按 168 小时执行，历史数据没有丢失。
+
+## 设计范围
+
+- 将请求历史预设窗口中的 `7d` 修正为 `7 * 24` 小时。
+- 增加覆盖 7 小时之外、7 天以内记录的回归测试。
+- 保持 1 小时、6 小时、24 小时、自定义范围和七天保留策略不变。
+
+## 非目标
+
+- 不修改 Token 用量统计窗口。
+- 不迁移或改写现有 SQLite 数据。
+- 不调整请求历史保留时长和分页上限。
+
+## 兼容性
+
+接口参数和响应格式不变，只修正 `window=7d` 的查询边界。无需配置或数据库迁移，版本选择 `patch`。
+
+## 风险
+
+近七天结果数量会恢复为预期值，查询数据量可能高于错误实现；现有时间索引和分页限制继续控制查询成本。
+
+## 测试计划
+
+- 运行请求历史聚焦测试，验证 8 小时前的记录只出现在 `7d`，不出现在 `6h`。
+- 运行相关核心测试并执行 `git diff --check`。
+
+## 实际改动
+
+- `local_proxy/core.py` 将请求记录预设 `7d` 的小时数从 7 修正为 `7 * 24`。
+- `tests/test_proxy_core.py` 增加 8 小时前记录在 `6h` 与 `7d` 窗口中的边界回归测试。
+
+## 验证结果
+
+- `python -m unittest tests.test_proxy_core.UsageTests.test_request_history_uses_full_168_hour_window_for_seven_days tests.test_proxy_core.UsageTests.test_custom_request_range_filters_and_enforces_seven_day_retention tests.test_proxy_core.UsageTests.test_request_history_cleanup_is_throttled`：3 项通过。
+- `.\\.venv\\Scripts\\python.exe -m unittest discover -s tests -p "test_*.py"`：514 项通过。
+- `python -m compileall -q local_proxy tests` 与 `git diff --check`：通过。
+
+## PR
+
+pending

--- a/docs/changes/2026-08-31-request-history-seven-day-window.md
+++ b/docs/changes/2026-08-31-request-history-seven-day-window.md
@@ -53,4 +53,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/56

--- a/docs/changes/2026-08-31-streaming-response-terminal-cleanup.md
+++ b/docs/changes/2026-08-31-streaming-response-terminal-cleanup.md
@@ -1,0 +1,67 @@
++++
+id = "2026-08-31-streaming-response-terminal-cleanup"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 修复流式响应残留请求
+
+## 目标
+
+确保客户端断开、下游发送失败或 Responses SSE 已送达明确终止事件时，本地中转及时关闭响应生成器与上游连接，结算请求历史并删除运行中记录，避免残留项在重启后集中显示为失败。
+
+## 现状
+
+断开感知响应会并行发送流和监听 ASGI `http.disconnect`，但流发送任务在 `send()` 抛错或被取消时不保证显式关闭异步响应生成器。生成器若停在 `yield`，负责关闭上游、结束路由状态和删除 `inflight_requests` 的 `finally` 可能无法执行。Responses SSE 即使已经转发 `response.completed` 等协议终止事件，也仍会等待上游传输自然 EOF；上游连接若继续保持，旧请求会长期停留在 `receiving`。
+
+## 设计范围
+
+- 断开感知响应无论正常结束、ASGI 断开、下游发送失败还是外层取消，都显式关闭响应体异步迭代器并等待其清理路径完成。
+- 使用独立于 Token 持久化的增量 SSE 终止观察器，只在解析到完整协议事件时识别 `response.completed`、`response.failed`、`response.incomplete`、`error` 或 `[DONE]`。
+- 终止事件所在数据块先完整转发给客户端，再主动结束本地迭代、关闭上游，并沿用现有成功、失败和 Token 判定。
+- 清理保持幂等，正常 EOF、终止事件与断开竞争时不得重复扣减活动请求或重复写入历史。
+
+## 非目标
+
+- 不设置流式请求固定总时长，不中断仍在正常输出的高推理强度请求。
+- 不因为同一会话出现新请求就取消旧请求，避免误伤合法并发。
+- 不回写、删除或重新分类已有 `process_restarted` 历史记录。
+- 不改变供应商选择、重试、模型、推理强度或代理配置。
+
+## 兼容性
+
+接口、配置和数据库结构均不变。仅修正流式请求生命周期和协议终止后的收尾时机，属于向后兼容缺陷修复，版本选择 `patch`。
+
+## 风险
+
+终止事件若按字节子串识别可能误判模型输出，因此必须按完整 SSE 事件解析 JSON 类型；终止数据块必须先发送再关闭，防止客户端丢失最终 usage 或错误信息。外层取消期间的清理需要隔离取消传播，避免数据库线程已启动但请求记录尚未关联时再次中断。
+
+## 测试计划
+
+- 覆盖下游 `send()` 抛出 `OSError` 时响应生成器、上游流、活动状态和 inflight 记录均被清理。
+- 覆盖发送任务暂停期间收到 ASGI 断开时仍执行生成器清理。
+- 覆盖 `response.completed` 后上游永久不 EOF，响应仍成功结束并保存 Token。
+- 覆盖 `response.failed` 后上游永久不 EOF，响应仍按内嵌失败记录。
+- 覆盖跨数据块 SSE 终止事件、普通输出文本包含终止词和正常自然 EOF，防止误判。
+- 运行完整 Python 单测、JavaScript 测试与语法检查、Python 编译和差异检查。
+
+## 实际改动
+
+- `local_proxy/core.py` 让断开感知响应在正常结束、下游发送异常、ASGI 断开和外层取消路径中统一取消遗留任务，并显式、抗取消地关闭响应体异步迭代器，确保生成器 `finally` 完成上游关闭、路由状态结束和请求持久化。
+- `local_proxy/core.py` 让流空闲超时包装器在退出时继续关闭底层异步流；响应收尾同时显式关闭当前包装流和上游响应，避免预检后的迭代器停留在 `yield`。
+- `local_proxy/core.py` 新增完整 SSE 事件级终止观察器，跨任意 CR/LF 和数据块边界识别 Responses 终止事件与 `[DONE]`；终止块转发后主动结束响应，不再等待上游 TCP EOF。
+- `tests/test_proxy_core.py` 覆盖普通文本防误判、跨块终止事件、`[DONE]`、发送阻塞时断开、下游发送异常、成功终止后永久挂流和失败终止后永久挂流。
+
+## 验证结果
+
+- `.\.venv\Scripts\python.exe -m unittest tests.test_proxy_core.SSEPreflightTests.test_terminal_capture_requires_a_complete_protocol_event tests.test_proxy_core.SSEPreflightTests.test_terminal_capture_recognizes_done_and_failure_events tests.test_proxy_core.ProxyAppTests.test_client_disconnect_cancels_a_stalled_upstream_stream tests.test_proxy_core.ProxyAppTests.test_downstream_send_error_closes_suspended_response_body tests.test_proxy_core.ProxyAppTests.test_terminal_event_finishes_when_upstream_never_reaches_eof tests.test_proxy_core.ProxyAppTests.test_failure_terminal_event_finishes_stalled_upstream_as_failure`：6 项通过。
+- `.\.venv\Scripts\python.exe -m unittest tests.test_proxy_core`：118 项通过。
+- `.\.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"`：串行重跑 514 项通过。
+- 对 `tests/*.test.js` 逐文件执行 `node --test`：15 个文件、64 项通过；对 `proxy_static/src/*.js` 与 `provider_status/static/app.js` 执行 `node --check`：6 个文件通过。
+- `npm run build --prefix proxy_static`：通过，Vite 转换 26 个模块。
+- `.\.venv\Scripts\python.exe -m compileall -q provider_status local_proxy scripts tests` 与 `git diff --check`：通过，仅有仓库现有 LF/CRLF 转换提示。
+
+## PR
+
+pending

--- a/docs/changes/2026-08-31-streaming-response-terminal-cleanup.md
+++ b/docs/changes/2026-08-31-streaming-response-terminal-cleanup.md
@@ -64,4 +64,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/56

--- a/local_proxy/core.py
+++ b/local_proxy/core.py
@@ -219,15 +219,20 @@ async def _stream_with_idle_timeout(
     *,
     timeout_seconds: float = UPSTREAM_STREAM_IDLE_TIMEOUT_SECONDS,
 ) -> AsyncIterator[bytes]:
-    while True:
-        try:
-            chunk = await _next_stream_chunk(
-                stream,
-                timeout_seconds=timeout_seconds,
-            )
-        except StopAsyncIteration:
-            return
-        yield chunk
+    try:
+        while True:
+            try:
+                chunk = await _next_stream_chunk(
+                    stream,
+                    timeout_seconds=timeout_seconds,
+                )
+            except StopAsyncIteration:
+                return
+            yield chunk
+    finally:
+        close = getattr(stream, "aclose", None)
+        if close is not None:
+            await close()
 
 
 def _stream_idle_retry_summary(exc: UpstreamStreamIdleTimeout) -> str:
@@ -273,12 +278,14 @@ def _finalize_stream_captures(
 def _feed_stream_captures(
     usage_capture: Any | None,
     failure_capture: Any | None,
+    terminal_capture: Any | None,
     chunk: bytes,
-) -> None:
+) -> str | None:
     if usage_capture is not None:
         usage_capture.feed(chunk)
     if failure_capture is not None:
         failure_capture.feed(chunk)
+    return terminal_capture.feed(chunk) if terminal_capture is not None else None
 
 
 class DisconnectAwareStreamingResponse(StreamingResponse):
@@ -291,22 +298,42 @@ class DisconnectAwareStreamingResponse(StreamingResponse):
 
         stream_task = asyncio.create_task(self.stream_response(send))
         disconnect_task = asyncio.create_task(self.listen_for_disconnect(receive))
-        done, pending = await asyncio.wait(
-            {stream_task, disconnect_task},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        tasks = {stream_task, disconnect_task}
+        try:
+            done, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
-        if stream_task in done:
-            await stream_task
-        else:
-            await disconnect_task
+            if stream_task in done:
+                await stream_task
+            else:
+                await disconnect_task
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await self._close_body_iterator()
 
         if self.background is not None:
             await self.background()
+
+    async def _close_body_iterator(self) -> None:
+        close = getattr(self.body_iterator, "aclose", None)
+        if close is None:
+            return
+        close_task = asyncio.create_task(close())
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            with suppress(asyncio.CancelledError, Exception):
+                await close_task
+            raise
 
 
 SSE_MODEL_CAPACITY_CODE_RE = re.compile(
@@ -743,7 +770,9 @@ class UsageStore:
             if cutoff < timestamp - REQUEST_HISTORY_HOURS * 3600:
                 raise ValueError("自定义时间不能早于最近 7 天的保留范围")
         else:
-            hours = {"1h": 1, "6h": 6, "24h": 24, "7d": 7}[normalized_window]
+            hours = {"1h": 1, "6h": 6, "24h": 24, "7d": 7 * 24}[
+                normalized_window
+            ]
             cutoff = timestamp - hours * 3600
             upper_bound = None
         bounded_limit = max(1, min(int(limit), REQUEST_HISTORY_PAGE_LIMIT))
@@ -4277,6 +4306,9 @@ async def _forward_request(
             and hasattr(protocol_adapter, "failure_capture")
             else SSEFailureCapture()
         )
+    terminal_capture = (
+        SSETerminalCapture() if _is_event_stream(upstream_response) else None
+    )
 
     async def response_body() -> AsyncIterator[bytes]:
         stream_failure: tuple[str, str] | None = None
@@ -4286,10 +4318,11 @@ async def _forward_request(
         persistence_ready = False
         try:
             if first_chunk is not None:
-                await asyncio.to_thread(
+                terminal_event = await asyncio.to_thread(
                     _feed_stream_captures,
                     usage_capture,
                     failure_capture,
+                    terminal_capture,
                     first_chunk,
                 )
                 router.update_request_phase(snapshot, "receiving", activity=True)
@@ -4298,17 +4331,26 @@ async def _forward_request(
                     snapshot.request_id,
                     phase="receiving",
                 )
+                if terminal_event is not None:
+                    stream_completed = True
                 yield first_chunk
+                if terminal_event is not None:
+                    return
             assert stream is not None
             async for chunk in stream:
-                await asyncio.to_thread(
+                terminal_event = await asyncio.to_thread(
                     _feed_stream_captures,
                     usage_capture,
                     failure_capture,
+                    terminal_capture,
                     chunk,
                 )
                 router.update_request_phase(snapshot, "receiving", activity=True)
+                if terminal_event is not None:
+                    stream_completed = True
                 yield chunk
+                if terminal_event is not None:
+                    return
             stream_completed = True
         except UpstreamStreamIdleTimeout as exc:
             stream_failure = (
@@ -4360,36 +4402,41 @@ async def _forward_request(
                 persistence_ready = True
             finally:
                 try:
-                    await upstream_response.aclose()
+                    close_stream = getattr(stream, "aclose", None)
+                    if close_stream is not None:
+                        await close_stream()
                 finally:
-                    router.finish_request(
-                        snapshot,
-                        status_code=upstream_response.status_code,
-                        error=history_kind,
-                    )
-                    if persistence_ready:
-                        await _record_stream_completion_async(
-                            usage_store,
-                            recovery_history_store,
-                            snapshot=snapshot,
-                            thread_id=thread_id,
-                            session_name_resolver=session_name_resolver,
-                            model=(
-                                usage_capture.model
-                                if usage_capture is not None
-                                else model
-                            ),
-                            reasoning_effort=reasoning_effort,
-                            usage=usage,
+                    try:
+                        await upstream_response.aclose()
+                    finally:
+                        router.finish_request(
+                            snapshot,
                             status_code=upstream_response.status_code,
-                            successful=successful,
-                            retry_count=max(0, attempt - 1),
-                            error_kind=history_kind,
-                            error_summary=history_summary,
-                            stream_failure=stream_failure,
-                            attempt=attempt,
-                            max_attempts=retry_policy.max_attempts,
+                            error=history_kind,
                         )
+                        if persistence_ready:
+                            await _record_stream_completion_async(
+                                usage_store,
+                                recovery_history_store,
+                                snapshot=snapshot,
+                                thread_id=thread_id,
+                                session_name_resolver=session_name_resolver,
+                                model=(
+                                    usage_capture.model
+                                    if usage_capture is not None
+                                    else model
+                                ),
+                                reasoning_effort=reasoning_effort,
+                                usage=usage,
+                                status_code=upstream_response.status_code,
+                                successful=successful,
+                                retry_count=max(0, attempt - 1),
+                                error_kind=history_kind,
+                                error_summary=history_summary,
+                                stream_failure=stream_failure,
+                                attempt=attempt,
+                                max_attempts=retry_policy.max_attempts,
+                            )
 
     return DisconnectAwareStreamingResponse(
         response_body(),
@@ -4757,6 +4804,48 @@ class SSEPreflightEventParser:
             return
         completed.append(b"\n".join(self._event_lines))
         self._event_lines.clear()
+
+
+class SSETerminalCapture:
+    """Recognize complete protocol terminal events across arbitrary chunks."""
+
+    _TERMINAL_EVENTS = frozenset(
+        {
+            "error",
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+        }
+    )
+
+    def __init__(self) -> None:
+        self._parser = SSEPreflightEventParser()
+        self._terminal_event: str | None = None
+
+    @property
+    def terminal_event(self) -> str | None:
+        return self._terminal_event
+
+    def feed(self, chunk: bytes) -> str | None:
+        if self._terminal_event is not None or not chunk:
+            return self._terminal_event
+        for event in self._parser.feed(chunk):
+            event_name, payload = _sse_event_payload(event)
+            if payload == b"[DONE]":
+                self._terminal_event = "[DONE]"
+                break
+            root = _decode_json(payload) if payload is not None else None
+            if not isinstance(root, dict):
+                continue
+            event_type = (
+                root.get("type")
+                if isinstance(root.get("type"), str)
+                else event_name
+            )
+            if event_type in self._TERMINAL_EVENTS:
+                self._terminal_event = event_type
+                break
+        return self._terminal_event
 
 
 def _sse_preflight_decision(

--- a/tests/test_proxy_core.py
+++ b/tests/test_proxy_core.py
@@ -25,6 +25,7 @@ from local_proxy.core import (
     RetryPolicy,
     RetryPolicyStore,
     SSECapacityFailureCapture,
+    SSETerminalCapture,
     TokenUsage,
     UsageCapture,
     UsageStore,
@@ -634,6 +635,29 @@ class UsageTests(unittest.TestCase):
                 now=now,
             )
 
+    def test_request_history_uses_full_168_hour_window_for_seven_days(self) -> None:
+        now = 2_000_000.0
+        recorded_at = now - 8 * 3600
+        self.store.record_request(
+            started_at=recorded_at,
+            finished_at=recorded_at,
+            provider_id="provider-a",
+            thread_id=None,
+            session_name="eight-hours-ago",
+            model="gpt-5",
+            status_code=200,
+            successful=True,
+            outcome="succeeded",
+            retry_count=0,
+        )
+
+        six_hours = self.store.request_history(window="6h", now=now)
+        seven_days = self.store.request_history(window="7d", now=now)
+
+        self.assertEqual(six_hours["total_count"], 0)
+        self.assertEqual(seven_days["total_count"], 1)
+        self.assertEqual(seven_days["items"][0]["session_name"], "eight-hours-ago")
+
     def test_request_history_cleanup_is_throttled(self) -> None:
         now = 2_000_000.0
         self.store.request_history(now=now)
@@ -917,6 +941,34 @@ class UsageTests(unittest.TestCase):
 
 
 class SSEPreflightTests(unittest.IsolatedAsyncioTestCase):
+    def test_terminal_capture_requires_a_complete_protocol_event(self) -> None:
+        capture = SSETerminalCapture()
+
+        self.assertIsNone(
+            capture.feed(
+                b'data: {"type":"response.output_text.delta",'
+                b'"delta":"literal response.completed text"}\n\n'
+                b'data: {"type":"response.com'
+            )
+        )
+        self.assertEqual(
+            capture.feed(b'pleted","response":{"status":"completed"}}\r\n\r\n'),
+            "response.completed",
+        )
+        self.assertEqual(capture.terminal_event, "response.completed")
+
+    def test_terminal_capture_recognizes_done_and_failure_events(self) -> None:
+        done = SSETerminalCapture()
+        failed = SSETerminalCapture()
+
+        self.assertEqual(done.feed(b"data: [DONE]\n\n"), "[DONE]")
+        self.assertEqual(
+            failed.feed(
+                b'event: response.failed\ndata: {"response":{"status":"failed"}}\n\n'
+            ),
+            "response.failed",
+        )
+
     def test_capacity_capture_respects_bare_cr_event_boundaries(self) -> None:
         separate_events = SSECapacityFailureCapture()
         self.assertIsNone(
@@ -4396,6 +4448,7 @@ class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
         async def send(message):
             if message["type"] == "http.response.body" and message.get("body"):
                 first_body_sent.set()
+                await never_continue.wait()
 
         await asyncio.wait_for(response(scope, response_receive, send), timeout=1)
         await upstream_client.aclose()
@@ -4406,6 +4459,232 @@ class ProxyAppTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(history["total_count"], 1)
         self.assertEqual(history["items"][0]["error_kind"], "client_disconnected")
         self.assertEqual(history["items"][0]["error_summary"], "客户端取消")
+
+    async def test_downstream_send_error_closes_suspended_response_body(self) -> None:
+        stream_closed = asyncio.Event()
+        never_continue = asyncio.Event()
+
+        class StalledStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield b'data: {"type":"response.output_text.delta","delta":"partial"}\n\n'
+                await never_continue.wait()
+
+            async def aclose(self) -> None:
+                stream_closed.set()
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=StalledStream(),
+            )
+
+        temp_context = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_context.cleanup)
+        usage_store = UsageStore(Path(temp_context.name) / "usage.sqlite3")
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        router = ProviderRouter((provider("selected", current=True),))
+        app = create_proxy_app(router, client=upstream_client, usage_store=usage_store)
+        route = next(
+            route for route in app.routes if getattr(route, "path", "") == "/v1/{upstream_path:path}"
+        )
+        from starlette.requests import Request
+
+        request_body_sent = False
+
+        async def request_receive():
+            nonlocal request_body_sent
+            if request_body_sent:
+                return {"type": "http.disconnect"}
+            request_body_sent = True
+            return {
+                "type": "http.request",
+                "body": b'{"model":"test"}',
+                "more_body": False,
+            }
+
+        scope = {
+            "type": "http", "asgi": {"spec_version": "2.4"},
+            "method": "POST", "path": "/v1/responses",
+            "raw_path": b"/v1/responses", "query_string": b"", "headers": [],
+            "scheme": "http", "server": ("testserver", 80),
+            "client": ("127.0.0.1", 1), "root_path": "",
+        }
+        response = await route.endpoint("responses", Request(scope, request_receive))
+        never_disconnect = asyncio.Event()
+
+        async def response_receive():
+            await never_disconnect.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.body" and message.get("body"):
+                raise OSError("fixture downstream closed")
+
+        with self.assertRaises(OSError):
+            await asyncio.wait_for(response(scope, response_receive, send), timeout=1)
+        await upstream_client.aclose()
+
+        self.assertTrue(stream_closed.is_set())
+        self.assertEqual(router.status().active_request_details, ())
+        history = usage_store.request_history()
+        self.assertEqual(history["total_count"], 1)
+        self.assertEqual(history["items"][0]["error_kind"], "client_disconnected")
+        with closing(sqlite3.connect(usage_store.path)) as connection:
+            inflight_count = connection.execute(
+                "SELECT COUNT(*) FROM inflight_requests"
+            ).fetchone()[0]
+        self.assertEqual(inflight_count, 0)
+
+    async def test_terminal_event_finishes_when_upstream_never_reaches_eof(self) -> None:
+        stream_closed = asyncio.Event()
+        never_continue = asyncio.Event()
+
+        class StalledAfterCompleted(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield (
+                    b'data: {"type":"response.completed","response":{"status":"completed",'
+                    b'"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}\n\n'
+                )
+                await never_continue.wait()
+
+            async def aclose(self) -> None:
+                stream_closed.set()
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=StalledAfterCompleted(),
+            )
+
+        temp_context = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_context.cleanup)
+        usage_store = UsageStore(Path(temp_context.name) / "usage.sqlite3")
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        router = ProviderRouter((provider("selected", current=True),))
+        app = create_proxy_app(router, client=upstream_client, usage_store=usage_store)
+        route = next(
+            route for route in app.routes if getattr(route, "path", "") == "/v1/{upstream_path:path}"
+        )
+        from starlette.requests import Request
+
+        request_body_sent = False
+
+        async def request_receive():
+            nonlocal request_body_sent
+            if request_body_sent:
+                return {"type": "http.disconnect"}
+            request_body_sent = True
+            return {
+                "type": "http.request",
+                "body": b'{"model":"test"}',
+                "more_body": False,
+            }
+
+        scope = {
+            "type": "http", "asgi": {"spec_version": "2.4"},
+            "method": "POST", "path": "/v1/responses",
+            "raw_path": b"/v1/responses", "query_string": b"", "headers": [],
+            "scheme": "http", "server": ("testserver", 80),
+            "client": ("127.0.0.1", 1), "root_path": "",
+        }
+        response = await route.endpoint("responses", Request(scope, request_receive))
+        never_disconnect = asyncio.Event()
+        sent_body = bytearray()
+
+        async def response_receive():
+            await never_disconnect.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.body":
+                sent_body.extend(message.get("body", b""))
+
+        await asyncio.wait_for(response(scope, response_receive, send), timeout=1)
+        await upstream_client.aclose()
+
+        self.assertIn(b"response.completed", sent_body)
+        self.assertTrue(stream_closed.is_set())
+        self.assertEqual(router.status().active_request_details, ())
+        history = usage_store.request_history()
+        self.assertEqual(history["total_count"], 1)
+        self.assertTrue(history["items"][0]["succeeded"])
+        self.assertEqual(history["items"][0]["total_tokens"], 12)
+
+    async def test_failure_terminal_event_finishes_stalled_upstream_as_failure(self) -> None:
+        stream_closed = asyncio.Event()
+        never_continue = asyncio.Event()
+
+        class StalledAfterFailure(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield (
+                    b'data: {"type":"response.output_text.delta","delta":"partial"}\n\n'
+                    b'data: {"type":"response.failed","response":{"status":"failed",'
+                    b'"error":{"code":"upstream_error","message":"try again later"}}}\n\n'
+                )
+                await never_continue.wait()
+
+            async def aclose(self) -> None:
+                stream_closed.set()
+
+        async def upstream(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=StalledAfterFailure(),
+            )
+
+        temp_context = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_context.cleanup)
+        usage_store = UsageStore(Path(temp_context.name) / "usage.sqlite3")
+        upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        router = ProviderRouter((provider("selected", current=True),))
+        app = create_proxy_app(router, client=upstream_client, usage_store=usage_store)
+        route = next(
+            route for route in app.routes if getattr(route, "path", "") == "/v1/{upstream_path:path}"
+        )
+        from starlette.requests import Request
+
+        request_body_sent = False
+
+        async def request_receive():
+            nonlocal request_body_sent
+            if request_body_sent:
+                return {"type": "http.disconnect"}
+            request_body_sent = True
+            return {
+                "type": "http.request",
+                "body": b'{"model":"test"}',
+                "more_body": False,
+            }
+
+        scope = {
+            "type": "http", "asgi": {"spec_version": "2.4"},
+            "method": "POST", "path": "/v1/responses",
+            "raw_path": b"/v1/responses", "query_string": b"", "headers": [],
+            "scheme": "http", "server": ("testserver", 80),
+            "client": ("127.0.0.1", 1), "root_path": "",
+        }
+        response = await route.endpoint("responses", Request(scope, request_receive))
+        never_disconnect = asyncio.Event()
+
+        async def response_receive():
+            await never_disconnect.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            return None
+
+        await asyncio.wait_for(response(scope, response_receive, send), timeout=1)
+        await upstream_client.aclose()
+
+        self.assertTrue(stream_closed.is_set())
+        self.assertEqual(router.status().active_request_details, ())
+        history = usage_store.request_history()
+        self.assertEqual(history["total_count"], 1)
+        self.assertFalse(history["items"][0]["succeeded"])
+        self.assertEqual(history["items"][0]["error_kind"], "upstream_error")
 
     async def test_forwards_request_stream_headers_query_and_response(self) -> None:
         observed: dict[str, object] = {}


### PR DESCRIPTION
## 变更说明
本 PR 合并两个此前仅存在于本地的 bug 修复：
- 修正请求历史 7d 窗口为完整 168 小时。
- 完善 Responses SSE 在明确终止事件、客户端断开和下游发送异常时的清理，避免活动请求和历史记录残留。
- 增加回归测试。
 
变更记录：
- docs/changes/2026-08-31-request-history-seven-day-window.md`n- docs/changes/2026-08-31-streaming-response-terminal-cleanup.md`n 
## 风险与兼容性
接口、配置和数据库结构不变；流式响应仅在解析到完整协议终止事件后提前完成收尾。版本影响为两个 patch 修复。
 
## 验证
- Python 全量单测：514 项通过。
- JavaScript 测试：15 个文件、64 项通过。
- JavaScript 语法检查、Python 编译、Vite 构建和 git diff --check：通过。
- pre-push 门禁：通过。