### PR TITLE
🐞 修复启动器测试的 macOS 跨平台兼容性

### DIFF
--- a/docs/changes/2026-09-03-portable-launcher-tests.md
+++ b/docs/changes/2026-09-03-portable-launcher-tests.md
@@ -67,4 +67,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/70

--- a/docs/changes/2026-09-03-portable-launcher-tests.md
+++ b/docs/changes/2026-09-03-portable-launcher-tests.md
@@ -1,0 +1,70 @@
++++
+id = "2026-09-03-portable-launcher-tests"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 跨平台启动器测试
+
+## 目标
+
+修复 macOS 发布工作流中因 Windows 专用环境变量和隐藏启动器断言导致的测试失败，同时保留 Windows 源码模式隐藏启动行为的覆盖。
+
+## 现状
+
+启动器产品逻辑已经按平台区分：Windows 且隐藏脚本可用时通过 `wscript.exe` 启动，其他平台使用直接 Python 命令。新增测试却无条件断言 `WINDIR` 和 `wscript.exe`，导致 macOS 上出现两个环境变量错误和一个错误断言。
+
+## 设计范围
+
+- 让源码模式自动启动命令测试按当前平台和可用运行时断言。
+- 在 Windows 环境继续验证 `wscript.exe`、隐藏 VBS 和 `pythonw.exe` 参数。
+- 在 macOS/Linux 环境验证直接 Python 启动命令，不读取 Windows 专用环境变量。
+- 保持启动器产品代码和 Windows 快捷方式行为不变。
+
+## 非目标
+
+- 不修改本地代理请求处理、托盘功能或启动器产品逻辑。
+- 不修改 GitHub Actions 的平台矩阵或发布流程。
+- 不删除已有启动器测试，只修正其平台假设。
+
+## 兼容性
+
+仅影响测试代码及其永久变更说明，不改变运行时配置、数据库、接口和用户启动方式。Windows、macOS 和 Linux 均可执行对应平台断言。
+
+## 风险
+
+平台条件写得过宽可能导致 Windows 隐藏启动路径失去覆盖，或在非 Windows 环境误测 Windows 行为。通过同时保留 Windows 专用断言和非 Windows 直接命令断言，并运行本机全量测试降低风险。
+
+## 测试计划
+
+- 运行启动器相关 Python 单测。
+- 运行 Python 全量单测和 JavaScript 全量测试。
+- 运行 Python 编译、Node 语法检查、Vue 构建和 `git diff --check`。
+- 确认 macOS 发布工作流的 Python 测试不再因为 `WINDIR` 失败。
+
+## 自审
+
+- 测试只读取产品现有的 `_hidden_source_proxy_command` 平台分支，不引入新的运行时分支。
+- Windows 断言仍覆盖隐藏启动脚本，非 Windows 断言覆盖当前实际直接启动命令。
+- 版本 bump 使用 `patch`，因为这是发布测试兼容性修复。
+
+## 实际改动
+
+- `tests/test_local_proxy_app.py` 使用明确的平台分支构造期望启动命令。
+- Windows 环境继续断言 `wscript.exe`、隐藏 VBS 和 `pythonw.exe` 参数。
+- macOS/Linux 环境断言直接 Python 启动命令，不读取 `WINDIR`。
+
+## 验证结果
+
+- `.venv\\Scripts\\python.exe -m unittest tests.test_local_proxy_app`：25 项通过。
+- `.venv\\Scripts\\python.exe -m unittest discover -s tests -p "test_*.py"`：541 项通过，耗时 76.358 秒。
+- `Get-ChildItem -Path tests -File -Filter *.test.js | Sort-Object Name | ForEach-Object { node --test $_.FullName; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } }`：18 个 JavaScript 测试文件、91 项通过。
+- `npm run build --prefix proxy_static`：Vite 生产构建通过，转换 29 个模块。
+- `.venv\\Scripts\\python.exe -m compileall -q provider_status local_proxy scripts tests`：通过。
+- `node --check proxy_static/classic/app.js` 及 `proxy_static/src`、`provider_status/static` 下 JavaScript 文件：通过。
+- `git diff --check`：通过。
+
+## PR
+
+pending

--- a/tests/test_local_proxy_app.py
+++ b/tests/test_local_proxy_app.py
@@ -33,6 +33,25 @@ from local_proxy.shared_settings import (
 )
 
 
+def expected_source_proxy_command(executable: Path) -> list[str]:
+    pythonw = executable.with_name("pythonw.exe")
+    runtime = (
+        pythonw
+        if executable.name.casefold() == "python.exe" and pythonw.is_file()
+        else executable
+    )
+    script = Path(local_proxy_app.__file__).resolve().parents[1] / "local_proxy_app.py"
+    direct_command = [str(runtime), str(script), "--tray", "--no-browser"]
+    if os.name != "nt":
+        return direct_command
+
+    launcher = script.parent / "scripts" / "start_local_proxy_hidden.vbs"
+    wscript = Path(os.environ.get("WINDIR", r"C:\Windows")) / "System32" / "wscript.exe"
+    if launcher.is_file() and wscript.is_file():
+        return [str(wscript), str(launcher), *direct_command]
+    return direct_command
+
+
 class LocalProxySettingsTests(unittest.TestCase):
     def test_ui_config_uses_unified_port_and_peer_console_path(self) -> None:
         config = codex_ui_config(19000)
@@ -231,12 +250,15 @@ class CodexConfigTests(unittest.TestCase):
             mock.patch.object(sys, "executable", executable),
         ):
             source_command = local_proxy_app.auto_start_command()
+            expected_source_command = subprocess.list2cmdline(
+                expected_source_proxy_command(Path(executable))
+            )
 
         self.assertEqual(
             frozen_command,
             subprocess.list2cmdline([executable, "--no-browser"]),
         )
-        self.assertIn("start_local_proxy_hidden.vbs", source_command)
+        self.assertEqual(source_command, expected_source_command)
         self.assertIn("local_proxy_app.py", source_command)
         self.assertIn("--tray", source_command)
         self.assertTrue(source_command.endswith("--no-browser"))
@@ -252,24 +274,12 @@ class CodexConfigTests(unittest.TestCase):
                 mock.patch.object(sys, "executable", str(executable)),
             ):
                 command = local_proxy_app.auto_start_command()
+                expected_command = subprocess.list2cmdline(
+                    expected_source_proxy_command(executable)
+                )
 
-        self.assertEqual(
-            command,
-            subprocess.list2cmdline(
-                [
-                    str(Path(os.environ["WINDIR"]) / "System32" / "wscript.exe"),
-                    str(
-                        Path(local_proxy_app.__file__).resolve().parents[1]
-                        / "scripts"
-                        / "start_local_proxy_hidden.vbs"
-                    ),
-                    str(pythonw.resolve()),
-                    str(Path(local_proxy_app.__file__).resolve().parents[1] / "local_proxy_app.py"),
-                    "--tray",
-                    "--no-browser",
-                ]
-            ),
-        )
+        self.assertEqual(command, expected_command)
+        self.assertIn(str(pythonw.resolve()), command)
 
     def test_legacy_source_auto_start_is_migrated_to_hidden_command(self) -> None:
         with (
@@ -349,13 +359,10 @@ class CodexConfigTests(unittest.TestCase):
             mock.patch.object(subprocess, "Popen") as popen,
         ):
             local_proxy_app.launch_replacement_process()
+            expected_command = expected_source_proxy_command(Path(sys.executable).resolve())
 
         command = popen.call_args.args[0]
-        self.assertEqual(
-            command[0],
-            str(Path(os.environ["WINDIR"]) / "System32" / "wscript.exe"),
-        )
-        self.assertEqual(Path(command[1]).name, "start_local_proxy_hidden.vbs")
+        self.assertEqual(command, expected_command)
         self.assertEqual(command[-2:], ["--tray", "--no-browser"])
 
     def test_tray_restart_stops_server_and_returns_restart_request(self) -> None:


### PR DESCRIPTION
## 功能修改

- 修复源码模式启动器测试在 macOS 上无条件读取 `WINDIR` 并断言 `wscript.exe` 的问题。
- 测试按平台验证：Windows 保留隐藏启动链断言，macOS/Linux 验证直接 Python 启动命令。

## 影响范围

- 仅影响 `tests/test_local_proxy_app.py` 和对应永久变更说明，不改变产品启动器、代理请求或发布配置。
- 修复 macOS Release 的测试兼容性；Windows 行为覆盖保持不变。

## 验证结果

- Python 全量单测：541 项通过。
- JavaScript 全量测试：18 个文件、91 项通过。
- `npm run build --prefix proxy_static`：Vite 29 个模块构建通过。
- Python compileall、Node 语法检查和 `git diff --check`：通过。
- pre-push 门禁：当前 head `e98d52e4c6f63042b15acd297313cce03458b3f0` 完整通过。

## 变更说明

- `docs/changes/2026-09-03-portable-launcher-tests.md`

## PR Head

- `e98d52e4c6f63042b15acd297313cce03458b3f0`