### PR TITLE
🐞 fix(hooks): 修复门禁中文报错乱码

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -2,5 +2,7 @@
 set -eu
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
+export PYTHONIOENCODING=utf-8
+export LC_ALL=C.UTF-8
 if python3 --version >/dev/null 2>&1; then PYTHON=python3; elif python --version >/dev/null 2>&1; then PYTHON=python; else echo "policy error: Python 3 is required" >&2; exit 1; fi
 exec "$PYTHON" scripts/team_policy.py commit-msg "$1"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,5 +2,7 @@
 set -eu
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
+export PYTHONIOENCODING=utf-8
+export LC_ALL=C.UTF-8
 if python3 --version >/dev/null 2>&1; then PYTHON=python3; elif python --version >/dev/null 2>&1; then PYTHON=python; else echo "policy error: Python 3 is required" >&2; exit 1; fi
 exec "$PYTHON" scripts/team_policy.py pre-commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,5 +2,7 @@
 set -eu
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
+export PYTHONIOENCODING=utf-8
+export LC_ALL=C.UTF-8
 if python3 --version >/dev/null 2>&1; then PYTHON=python3; elif python --version >/dev/null 2>&1; then PYTHON=python; else echo "policy error: Python 3 is required" >&2; exit 1; fi
 exec "$PYTHON" scripts/team_policy.py pre-push

--- a/docs/changes/2026-09-03-hook-encoding.md
+++ b/docs/changes/2026-09-03-hook-encoding.md
@@ -1,0 +1,60 @@
++++
+id = "2026-09-03-hook-encoding"
+type = "fix"
+release_bump = "none"
+status = "verified"
++++
+
+# 修复门禁中文报错乱码
+
+## 目标
+
+git-bash 下触发门禁失败时，中文 policy 报错在终端清晰可读，不再显示 `����`。
+
+## 现状
+
+`scripts/team_policy.py` 用普通 `print(..., file=sys.stderr)` 输出中文，编码跟随进程 locale；钩子跑在 git-bash（MSYS sh）下默认代码页非 UTF-8，中文在 sh→终端链路上被错误解码成乱码，难排查。
+
+## 设计范围
+
+- `.githooks/commit-msg、pre-commit、pre-push`：`export PYTHONIOENCODING=utf-8`（加 `LC_ALL=C.UTF-8` 兜底）。
+- `scripts/team_policy.py` 启动时重配 stdio 为 UTF-8（`errors="backslashreplace"`，try 包裹防管道异常），无环境变量时也不乱码。
+- 顺带把 #74 带入的 `proxy_static/dist/index.html` 换行符噪音（11 行 CRLF + 1 行孤立 `\r\r\n`）归一为 LF，保持主线干净；字节级验证零语义。
+- 报错文本一个字不改。
+
+## 非目标
+
+- 不改任何门禁规则与校验逻辑。
+- 不改其他脚本输出。
+
+## 兼容性
+
+无。仅输出编码，行为与接口不变；`none` 不触发发版。
+
+## 风险
+
+- 老环境 Python 若不支持 `reconfigure`：已 try 包裹降级，无影响。
+- 缓解：回归跑 `tests/test_team_policy.py`。
+
+## 测试计划
+
+- 故意触发一次门禁失败（如坏 commit-msg），同终端确认中文清晰。
+- 运行 `tests/test_team_policy.py`。
+
+## 实际改动
+
+- `.githooks/commit-msg、pre-commit、pre-push`：各加 `export PYTHONIOENCODING=utf-8` + `export LC_ALL=C.UTF-8`。
+- `scripts/team_policy.py`：新增 `_ensure_utf8_stdio()` 并在 `main()` 入口调用，stdio 重配 UTF-8（`backslashreplace`，异常吞掉降级）。
+- 新增本说明 `docs/changes/2026-09-03-hook-encoding.md`。
+- `proxy_static/dist/index.html`：归一 #74 带入的 CRLF（含 1 行 `\r\r\n`）为 LF。
+
+## 验证结果
+
+- A/B 对照（同终端同坏消息）：旧代码输出 `policy error: commit �������ʹ��ǰ�� emoji��Conventional Commit �ͼ�����������`；新代码经钩子输出 `policy error: commit 标题必须使用前置 emoji、Conventional Commit 和简体中文描述`，清晰可读。
+- `python -m unittest tests.test_team_policy`：25 tests OK。
+- dist 归一验证：去 CR 后与基线字节完全一致（零语义）；入库 blob CR=0。
+- 编辑后全文件换行符检查通过（`team_policy.py` 还原为 LF，diff 仅 +20 行）。
+
+## PR
+
+pending

--- a/proxy_static/dist/index.html
+++ b/proxy_static/dist/index.html
@@ -8,6 +8,6 @@
   <link rel="stylesheet" crossorigin href="./static/assets/index-CZSQ79a7.css">
 </head>
 <body>
-  <div id="app"></div>
+  <div id="app"></div>
 </body>
 </html>

--- a/scripts/team_policy.py
+++ b/scripts/team_policy.py
@@ -505,7 +505,21 @@ def command_pre_push(stdin: str) -> None:
     run_full_verification()
 
 
+def _ensure_utf8_stdio() -> None:
+    """Force UTF-8 stdio so Chinese policy errors stay readable under git-bash.
+
+    Hooks run with an MSYS locale whose default codepage is not UTF-8; without
+    this, PolicyError messages degrade into mojibake. Never raises.
+    """
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except Exception:
+            continue
+
+
 def main(argv: list[str] | None = None) -> int:
+    _ensure_utf8_stdio()
     parser = argparse.ArgumentParser(description="Repository delivery policy")
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("install-hooks")


### PR DESCRIPTION
## 功能说明

对应 `docs/changes/2026-09-03-hook-encoding.md`（verified，none）。

### 行为
- 三个 githooks 导出 `PYTHONIOENCODING=utf-8` + `LC_ALL=C.UTF-8`。
- `team_policy.py` 启动重配 stdio 为 UTF-8（backslashreplace 降级）；报错文本零改动。

### 风险
- 仅输出编码；门禁规则与校验逻辑不变；老 Python 不支持 reconfigure 时 try 包裹降级。

### 验证
- A/B 对照：旧代码同场景输出 `����` 乱码，新代码输出清晰中文。
- `tests.test_team_policy`：25 tests OK；改动 diff 仅 +20 行。
