### PR TITLE
🐳 chore(policy): 全量验证改基线对比并取消自动发版

### DIFF
--- a/.agents/skills/git-commit-helper/SKILL.md
+++ b/.agents/skills/git-commit-helper/SKILL.md
@@ -18,9 +18,9 @@ All repository delivery goes through a feature branch, a permanent change record
 5. Inspect `git status --short`, staged diff, and unstaged diff. Split unrelated concerns and stage explicit paths only. Never use `git add .` or `git add -A`.
 6. After implementation and focused tests, update the record to `implemented`. After fresh full verification, update it to `verified` and record exact commands/results.
 7. Commit with `emoji type(scope): 简体中文描述`. Every body must contain non-empty `功能修改`, `影响范围`, and `验证结果` headings. Never add AI attribution or `Co-authored-by`.
-8. Rebase on current `origin/main`, rerun full verification, and push only the feature branch.
-9. Create or update the PR with the record summary, risks, and verification. Attempt to enable `auto-merge` (expected to fail while the ruleset does not enable `allow_auto_merge`); do not request human approval. PR 阶段不运行 CI，无 required checks；merge 只要求 PR 存在且无冲突。 Merge with `gh pr merge --squash` or the web UI's Squash and merge (gh CLI not required) using the PR's exact head SHA (准确 head SHA) and verify the resulting merge commit; never merge by branch name, stale SHA, ambiguous ref, or an unverified state. 完整测试（Python 单测、JS 语法检查、JS 测试）由 release tag 触发的 `windows-release.yml` / `macos-release.yml` 全量执行并阻塞发布。
-10. Never create or push tags manually. The main-branch release coordinator selects SemVer from verified change records and dispatches both release workflows. Report the PR URL, squash merge result, release workflow URL, and both platform workflow results.
+8. Rebase on current `origin/main`, rerun full verification, and push only the feature branch. 全量验证为基线对比：与 merge-base 基线相同的既有失败放行且无需排查，只拦截本次新增的失败（会复跑一次确认，偶发失败不阻塞）；`npm ci`、构建与 `node --check` 仍必须通过。
+9. Create or update the PR with the record summary, risks, and verification. Attempt to enable `auto-merge` (expected to fail while the ruleset does not enable `allow_auto_merge`); do not request human approval. PR 阶段不运行 CI，无 required checks；merge 只要求 PR 存在且无冲突。 Merge with `gh pr merge --squash` or the web UI's Squash and merge (gh CLI not required) using the PR's exact head SHA (准确 head SHA) and verify the resulting merge commit; never merge by branch name, stale SHA, ambiguous ref, or an unverified state. 完整测试（Python 单测、JS 语法检查、JS 测试）由 release tag 触发的 `windows-release.yml` / `macos-release.yml` 全量执行并阻塞发布，发布环境无基线豁免。
+10. Never create or push tags manually. After the squash merge there is **no automatic release**: summarize the `verified` records added since the last tag, propose the version bump and release notes to the user, and trigger the release workflow only after the user explicitly consents (`gh workflow run release.yml --ref main`, or the user runs it from the web UI). The release workflow selects SemVer from verified change records, creates the unique tag, and dispatches both platform workflows. Report the PR URL, squash merge result, release workflow URL, and both platform workflow results.
 
 ## Commit Types
 
@@ -54,7 +54,7 @@ All repository delivery goes through a feature branch, a permanent change record
 
 ## Stop Conditions
 
-Stop and report the blocker when the branch is stale, a changed file is not understood, a record is absent/incomplete, local tests fail or were not run, or repository administration prevents merge/ruleset enforcement. Never use `--no-verify`, force push, `git push --all`, or `git push --tags` as a workaround.
+Stop and report the blocker when the branch is stale, a changed file is not understood, a record is absent/incomplete, full verification was not run or shows failures beyond the merge-base baseline, or repository administration prevents merge/ruleset enforcement. Never use `--no-verify`, force push, `git push --all`, or `git push --tags` as a workaround. Baseline-known failures (present on merge-base) pass through without investigation; never fabricate a baseline entry to excuse a new failure.
 
 | Rationalization | Required response |
 |---|---|

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
-name: Automatic Release
+name: Manual Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,18 +31,20 @@ python scripts/team_policy.py install-hooks
 - 每次提交前必须检查完整 staged/unstaged diff，并按独立关注点拆分。
 - commit 标题必须为前置 emoji 的 Conventional Commit 中文描述；正文必须包含非空的 `功能修改`、`影响范围`、`验证结果`。
 - 禁止直接推送 `main` 和任何标签。功能分支必须 rebase 到最新 `origin/main` 并针对准确 HEAD 重新完整验证。
+- pre-push 全量验证采用基线对比：与 merge-base（`origin/main`）基线相同的既有失败直接放行、不要求排查；只拦截本次改动新增的失败（新增失败会复跑一次确认，偶发失败不阻塞）。`npm ci`、构建与 `node --check` 仍必须全部通过。
 - Agent 必须创建或更新 PR、填写功能说明和验证证据，并尝试启用 auto-merge（当前规则集未开放 `allow_auto_merge`，启用失败属预期）。
 - PR 阶段不运行 CI，PR 不要求人工审批、无 required status checks；合并仅要求 PR 存在且无冲突。
-- 完整测试（Python 单测、JS 语法检查、JS 测试）在 release tag 时由 `windows-release.yml` / `macos-release.yml` 全量执行并阻塞发布。
+- 完整测试（Python 单测、JS 语法检查、JS 测试）在 release tag 时由 `windows-release.yml` / `macos-release.yml` 全量执行并阻塞发布，且必须全部通过（发布环境是干净 runner，无基线豁免）。
 - 合并使用 squash 方式（`gh pr merge --squash` 或网页 Squash and merge 均可，不强制 gh CLI），以 PR 的最新准确 head SHA 执行，合并后验证目标提交；禁止使用分支名、旧 SHA、模糊 ref 或无 SHA 合并，禁止绕过门禁直接改动远端。
 
-## 自动版本与自动发版
+## 版本与人工确认发版
 
 - Agent 在功能说明中根据兼容性选择 `major`、`minor`、`patch` 或 `none`，并在说明中给出理由，不等待人工决定版本号。
-- PR 合并后由 `auto-release` 工作流读取自上个标签以来新增且 `verified` 的说明，选择最高 bump、生成 release notes、创建唯一标签，并显式触发 Windows 与 macOS 发布工作流。
-- 正常流程禁止 Agent 手工创建或推送标签。只有自动发布工作流可以执行标签操作。
-- Agent 必须跟踪 PR 状态（无 CI 检查）、squash 合并、自动发布和两个平台发布结果，报告 URL、状态和具体失败步骤。
+- 合并后**不再自动发版**。Agent 必须汇总自上个标签以来新增且 `verified` 的说明，给出拟定版本号与 release notes 摘要，明确询问用户是否发布；用户同意前禁止触发任何发版动作。
+- 用户同意后，Agent 触发 `release` 工作流（`gh workflow run release.yml --ref main`，或用户在网页手动触发）。发版工作流读取 verified 说明、选择最高 bump、生成 release notes、创建唯一标签，并显式触发 Windows 与 macOS 发布工作流。
+- 正常流程禁止 Agent 手工创建或推送标签。只有发版工作流可以执行标签操作。
+- Agent 必须跟踪 PR 状态（无 CI 检查）、squash 合并、发版工作流和两个平台发布结果，报告 URL、状态和具体失败步骤。
 
 ## 硬停止条件
 
-以下任一情况必须停止：主线未同步；处于受保护分支；功能说明缺失或状态不匹配；diff 含不理解/无关/敏感文件；本地测试未运行或失败；Ruleset 未验证；合并或发布权限不足。不得声称流程完成。
+以下任一情况必须停止：主线未同步；处于受保护分支；功能说明缺失或状态不匹配；diff 含不理解/无关/敏感文件；本地全量验证未运行，或出现基线之外的新增失败；Ruleset 未验证；合并或发布权限不足。不得声称流程完成。

--- a/docs/changes/2026-09-03-verification-baseline-manual-release.md
+++ b/docs/changes/2026-09-03-verification-baseline-manual-release.md
@@ -1,0 +1,82 @@
++++
+id = "2026-09-03-verification-baseline-manual-release"
+type = "chore"
+release_bump = "none"
+status = "verified"
++++
+
+# 全量验证基线对比与人工确认发版
+
+## 目标
+
+降低交付门禁的时间与 Agent token 成本，并让发版回归人工确认：
+
+1. 删除依赖真实桌面环境的 GUI 冒烟测试（`GuiSmokeTests`）。
+2. pre-push 全量验证改为**基线对比**：失败集合是 merge-base（origin/main）基线子集时放行、不排查；只拦截本次改动新增的失败。
+3. 发版从合并后自动触发改为**人工确认**：Agent 汇总待发布内容并向用户确认后，手动触发发版协调工作流创建标签并派发双平台发布。
+
+## 现状
+
+- `tests/test_probe_codex_gui.py` 的 `GuiSmokeTests` 依赖本机 cc-switch 数据库（≥1 个 Codex API 供应商）与 codex 二进制，在无供应商的机器上必失败，曾阻塞推送。
+- `run_full_verification()` 在 pre-push 无条件要求 549 项全部通过：任何与本改动无关的既有失败（如本机 fake-IP DNS 把保留域解析为非公网地址）都会阻塞，且 Agent 需消耗大量上下文排查以证明"非本次引入"。
+- `auto-release.yml` 在 push 到 main 时自动选版本、打标签、触发双平台发布，用户没有确认机会。
+
+## 设计范围
+
+1. 删除 `GuiSmokeTests` 及其专用 import；保留同文件两个纯单元测试类与 `--smoke-test` 脚本入口。
+2. `scripts/team_policy.py`：
+   - 全量验证拆为"硬门禁"（`npm ci`、`npm run build`、`node --check` 全部仍须通过）与"可比对套件"（Python unittest、逐文件 `node --test`）。
+   - 新增基线机制：按 merge-base SHA 把基线失败集合缓存到 `.git/policy-baselines/<sha>.json`；缓存缺失时在临时 worktree 检出 merge-base 运行可比对套件生成基线（不跑 npm）。
+   - HEAD 失败集合为基线子集 → 放行并打印忽略清单；出现新增失败 → 对新增项复跑一次确认（缓解偶发失败），仍失败才阻止。
+   - unittest 失败 ID 解析自 `FAIL|ERROR: name (id)` 行；node 失败解析自 TAP `not ok` 行。
+3. `auto-release.yml` 重命名为 `release.yml`，触发方式改为 `workflow_dispatch`；内部逻辑（读取 verified 说明、选最高 bump、创建唯一标签、显式派发 `windows-release.yml` / `macos-release.yml`）保持不变。
+4. `AGENTS.md` 与 `git-commit-helper` skill 同步：发版流程改为"Agent 提议版本与 notes → 用户同意 → 触发 release 工作流"；硬停止条件改为"全量验证未运行，或出现基线之外的新增失败"。
+
+## 非目标
+
+- 不改 release tag 时 `windows-release.yml` / `macos-release.yml` 的全量测试与阻塞行为（发布前最后一道闸门保持全量且必须全过）。
+- 不改 PR 阶段不跑 CI、squash 合并、Ruleset、提交白名单等既有门禁。
+- 不删除 `probe_codex_gui.py --smoke-test` 脚本本身（仍可手动运行）。
+
+## 兼容性
+
+- 无产品运行时影响，仅改交付工具链；`release_bump = "none"`，不产生产品版本发布。
+- 基线缓存位于 `.git/`（不提交、不进版本库），旧缓存条目在写入新基线时清理。
+- 已有 `release-plan` / `release-notes` CLI 与函数不变，发版工作流复用。
+
+## 风险
+
+1. 基线对比对偶发失败（flaky）不免疫：新增失败复跑一次确认后仍失败才拦截；基线侧偶发失败会进缓存导致放行偏松（可接受方向：宁松勿卡）。
+2. node 逐文件失败按测试名集合比对，个别 reporter 格式变化可能解析不到 → 解析为空集合等同"无既有失败"，退化为严格模式（安全方向）。
+3. 基线在临时 worktree 跑 Python 套件依赖本机环境（如 fake-IP DNS）：基线与 HEAD 在同一台机器运行，环境性失败同时出现在两侧，自动对消——这正是本设计要解决的问题。
+4. 自动发版取消后，若 Agent 忘记询问用户，改动会滞留在 main 未发布：由 skill 步骤强制要求合并后必须给出"发版或跳过"的提议收尾。
+
+## 测试计划
+
+- `tests/test_team_policy.py`：新增 unittest/TAP 失败解析、失败集合差集、基线缓存读写、release 工作流为手动触发且不自动 push 触发的断言；更新与 AGENTS.md/skill 新文案相关的治理断言。
+- 全量验证：`python -m unittest discover -s tests -p "test_*.py"`、`node --test tests/*.test.js`、`npm ci` + `npm run build --prefix proxy_static`。
+- 实际推送本分支时用新 pre-push 钩子走一遍真实基线对比（merge-base 为 origin/main）。
+
+## 实际改动
+
+- `scripts/team_policy.py`：
+  - 新增失败解析（`UNITTEST_FAILURE_RE`、`NODE_FAILURE_RE`、`parse_unittest_failures`、`parse_node_failures`）与哨兵常量（套件非零退出但解析不到失败 ID 时保守拦截）；
+  - `run_full_verification()` 重构：`npm ci`、`npm run build`、`node --check` 全部为硬门禁；Python unittest 与逐文件 `node --test` 改为"可比对套件"，失败集合与 merge-base 基线比对，子集放行（打印忽略数量），新增失败复跑一次确认后仍失败才阻止；
+  - 新增基线设施：`run_comparable_suites`、`diff_new_failures`、`_baseline_cache_path`（`.git/policy-baselines/<merge-base>.json`）、`read_baseline_cache`/`write_baseline_cache`（写入时清理旧缓存）、`collect_baseline`（临时 worktree 检出 merge-base 跑可比对套件，不跑 npm）、`load_or_build_baseline`、`_confirm_new_failures`。
+- `tests/test_probe_codex_gui.py`：删除 `GuiSmokeTests` 及其专用 import（json/os/subprocess/sys/Path/ROOT/GUI_SCRIPT）；保留两个纯单元测试类。
+- `.github/workflows/auto-release.yml` 重命名为 `release.yml`：名称改为 Manual Release，触发改为 `workflow_dispatch`；计划计算、标签创建与双平台派发逻辑不变。
+- `AGENTS.md`：Git 与 PR 增加基线对比条款；"自动版本与自动发版"改为"版本与人工确认发版"（合并后不自动发版，Agent 汇总并向用户确认后触发 `release.yml`）；硬停止条件改为"本地全量验证未运行，或出现基线之外的新增失败"。
+- `.agents/skills/git-commit-helper/SKILL.md`：第 8/9/10 步与停止条件同步新口径（基线对比、无自动发版、用户同意后 `gh workflow run release.yml --ref main`）。
+- `tests/test_team_policy.py`：治理断言更新（AGENTS/skill 新文案、release.yml 手动触发且 auto-release.yml 不存在）；新增 `VerificationBaselineTests` 6 项（unittest/TAP 失败解析、去重、子集放行与新增项判定、哨兵、基线缓存 roundtrip 与旧缓存清理）。
+
+## 验证结果
+
+- `python -m unittest tests.test_team_policy tests.test_probe_codex_gui tests.test_project_documentation` → 39 项全部通过（2026-09-03）。
+- 端到端演练基线机制（2026-09-03 15:10）：HEAD 可比对套件 18.6s 失败 0；merge-base（5f06e6e）基线 17.9s 失败 1（main 上仍存在的冒烟测试在本机 cc-switch 无供应商时失败）；`diff_new_failures` 为空 → 按新规则应放行且无需排查，行为符合设计；基线缓存已写入 `.git/policy-baselines/`。
+- `python -m unittest discover -s tests -p "test_*.py"` → 554 项全部通过（2026-09-03）。
+- `node --test tests/*.test.js`、`node --check`（classic/src/provider_status）、`npm ci` + `npm run build --prefix proxy_static` → 全部通过（2026-09-03）。
+- 实际推送本分支时由新版 pre-push 钩子执行真实基线对比（见 PR 与推送记录）。
+
+## PR
+
+pending

--- a/docs/changes/2026-09-03-verification-baseline-manual-release.md
+++ b/docs/changes/2026-09-03-verification-baseline-manual-release.md
@@ -79,4 +79,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/76

--- a/scripts/team_policy.py
+++ b/scripts/team_policy.py
@@ -4,8 +4,10 @@ import re
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import tomllib
 import urllib.error
 import urllib.request
@@ -59,6 +61,10 @@ ALLOWED_COMMIT_NAMES = frozenset(
     )
 )
 COAUTHOR_RE = re.compile(r"(?im)^\s*co-authored-by:\s*([^<]+?)\s*<[^>]+>\s*$")
+UNITTEST_FAILURE_RE = re.compile(r"^(?:FAIL|ERROR):\s+\S+\s+\(([^)\]]+)\)", re.MULTILINE)
+NODE_FAILURE_RE = re.compile(r"(?m)^[ \t]*not ok[ \t]+\d+[ \t]+-[ \t]+(.+?)[ \t]*(?:#.*)?$")
+PYTHON_SUITE_SENTINEL = "<python-suite-exit-nonzero>"
+NODE_SUITE_SENTINEL = "<node-suite-exit-nonzero>"
 
 
 class PolicyError(RuntimeError):
@@ -437,26 +443,198 @@ def validate_pr(base: str, head: str) -> None:
         validate_commit_identities(identities)
 
 
-def run_full_verification() -> None:
-    npm = "npm.cmd" if os.name == "nt" else "npm"
-    commands = [
-        [npm, "ci", "--prefix", "proxy_static"],
-        [npm, "run", "build", "--prefix", "proxy_static"],
-        [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py"],
-    ]
-    commands.append(["node", "--check", "proxy_static/classic/app.js"])
+def _npm_command() -> str:
+    return "npm.cmd" if os.name == "nt" else "npm"
+
+
+def _syntax_check_commands() -> list[list[str]]:
+    commands = [["node", "--check", "proxy_static/classic/app.js"]]
     commands.extend(
         ["node", "--check", str(path)]
         for path in sorted(Path("proxy_static/src").glob("*.js"))
     )
     commands.append(["node", "--check", "provider_status/static/app.js"])
-    commands.extend(
-        ["node", "--test", str(path)] for path in sorted(Path("tests").glob("*.test.js"))
+    return commands
+
+
+def _run_capture(command: list[str], *, cwd: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        command,
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
     )
-    for command in commands:
+    return result.returncode, (result.stdout or "") + (result.stderr or "")
+
+
+def parse_unittest_failures(output: str) -> list[str]:
+    return sorted(set(UNITTEST_FAILURE_RE.findall(output)))
+
+
+def parse_node_failures(output: str) -> list[str]:
+    return sorted({name.strip() for name in NODE_FAILURE_RE.findall(output)})
+
+
+def run_comparable_suites(root: Path) -> dict[str, object]:
+    """Run the Python and node suites; report failure ids (not exit codes)."""
+    code, output = _run_capture(
+        [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py"],
+        cwd=root,
+    )
+    python_failures = parse_unittest_failures(output)
+    if code != 0 and not python_failures:
+        python_failures = [PYTHON_SUITE_SENTINEL]
+
+    node_failures: dict[str, list[str]] = {}
+    for test_file in sorted((root / "tests").glob("*.test.js")):
+        code, output = _run_capture(["node", "--test", str(test_file)], cwd=root)
+        if code == 0:
+            continue
+        names = parse_node_failures(output)
+        node_failures[str(test_file.relative_to(root)).replace("\\", "/")] = (
+            names or [NODE_SUITE_SENTINEL]
+        )
+    return {"python": python_failures, "node": node_failures}
+
+
+def diff_new_failures(head: dict[str, object], baseline: dict[str, object]) -> list[str]:
+    """Failures present on HEAD but absent from the merge-base baseline."""
+    new_items: list[str] = []
+    base_python = set(baseline.get("python", ()) or ())
+    for test_id in sorted(set(head.get("python", ()) or ()) - base_python):
+        new_items.append(f"python {test_id}")
+    base_node = baseline.get("node", {}) or {}
+    head_node = head.get("node", {}) or {}
+    for file, names in sorted(head_node.items()):
+        base_names = set(base_node.get(file, ()) or ())
+        for name in sorted(set(names or ()) - base_names):
+            new_items.append(f"node {file} :: {name}")
+    return new_items
+
+
+def _baseline_cache_path(merge_base: str) -> Path:
+    git_dir = Path(run_git(["rev-parse", "--absolute-git-dir"]))
+    cache_dir = git_dir / "policy-baselines"
+    return cache_dir / f"{merge_base}.json"
+
+
+def read_baseline_cache(merge_base: str) -> dict[str, object] | None:
+    cache = _baseline_cache_path(merge_base)
+    try:
+        loaded = json.loads(cache.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    return loaded
+
+
+def write_baseline_cache(merge_base: str, baseline: dict[str, object]) -> None:
+    cache = _baseline_cache_path(merge_base)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    for stale in cache.parent.glob("*.json"):
+        stale.unlink(missing_ok=True)
+    cache.write_text(json.dumps(baseline, ensure_ascii=False, indent=1), encoding="utf-8")
+
+
+def collect_baseline(merge_base: str) -> dict[str, object]:
+    """Run the comparable suites in a throwaway worktree of merge_base."""
+    workdir = tempfile.mkdtemp(prefix="policy-baseline-")
+    worktree = Path(workdir) / "baseline"
+    run_git(["worktree", "add", "--detach", "--quiet", str(worktree), merge_base])
+    try:
+        return run_comparable_suites(worktree)
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", "--quiet", str(worktree)],
+            check=False,
+            capture_output=True,
+        )
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def load_or_build_baseline(merge_base: str) -> dict[str, object]:
+    cached = read_baseline_cache(merge_base)
+    if cached is not None:
+        return cached
+    baseline = collect_baseline(merge_base)
+    write_baseline_cache(merge_base, baseline)
+    return baseline
+
+
+def _confirm_new_failures(new_failures: list[str]) -> list[str]:
+    """Rerun newly failing targets once to filter out flaky one-offs."""
+    confirmed: list[str] = []
+    python_ids = [
+        item.removeprefix("python ").strip()
+        for item in new_failures
+        if item.startswith("python ") and not item.endswith(PYTHON_SUITE_SENTINEL)
+    ]
+    if python_ids:
+        code, output = _run_capture(
+            [sys.executable, "-m", "unittest", *python_ids], cwd=Path(".")
+        )
+        if code != 0:
+            still = set(parse_unittest_failures(output))
+            confirmed.extend(
+                f"python {test_id}" for test_id in sorted(still or set(python_ids))
+            )
+    if any(item == f"python {PYTHON_SUITE_SENTINEL}" for item in new_failures):
+        confirmed.append(f"python {PYTHON_SUITE_SENTINEL}")
+
+    node_files = sorted(
+        {
+            item.removeprefix("node ").split(" :: ")[0]
+            for item in new_failures
+            if item.startswith("node ") and NODE_SUITE_SENTINEL not in item
+        }
+    )
+    for file in node_files:
+        code, output = _run_capture(["node", "--test", file], cwd=Path("."))
+        if code != 0:
+            names = set(parse_node_failures(output))
+            confirmed.extend(
+                f"node {file} :: {name}"
+                for name in sorted(names) or [NODE_SUITE_SENTINEL]
+            )
+    confirmed.extend(
+        item for item in new_failures if NODE_SUITE_SENTINEL in item and item not in confirmed
+    )
+    return confirmed
+
+
+def run_full_verification() -> None:
+    """Hard gates must pass; suite failures only block when new vs the baseline."""
+    for command in [
+        [_npm_command(), "ci", "--prefix", "proxy_static"],
+        [_npm_command(), "run", "build", "--prefix", "proxy_static"],
+        *_syntax_check_commands(),
+    ]:
         result = subprocess.run(command, check=False)
         if result.returncode != 0:
             raise PolicyError(f"验证失败：{' '.join(command)}")
+
+    head = run_comparable_suites(Path("."))
+    merge_base = run_git(["merge-base", "origin/main", "HEAD"])
+    baseline = load_or_build_baseline(merge_base)
+    new_failures = diff_new_failures(head, baseline)
+    confirmed: list[str] = []
+    if new_failures:
+        confirmed = _confirm_new_failures(new_failures)
+    if confirmed:
+        detail = "\n".join(f"- {item}" for item in confirmed)
+        raise PolicyError(
+            f"全量验证出现基线之外的新增失败（merge-base {merge_base}），禁止推送：\n{detail}"
+        )
+    ignored = len(head.get("python", []) or []) + sum(
+        len(names) for names in (head.get("node", {}) or {}).values()
+    )
+    print(
+        f"pre-push 全量验证通过：忽略基线既有失败 {ignored} 项，无新增失败。"
+    )
 
 
 def command_install_hooks() -> None:

--- a/tests/test_probe_codex_gui.py
+++ b/tests/test_probe_codex_gui.py
@@ -1,13 +1,4 @@
-import json
-import os
-import subprocess
-import sys
 import unittest
-from pathlib import Path
-
-
-ROOT = Path(__file__).resolve().parents[1]
-GUI_SCRIPT = ROOT / "probe_codex_gui.py"
 
 
 class ResultDetailTests(unittest.TestCase):
@@ -40,32 +31,6 @@ class AttemptProgressTests(unittest.TestCase):
             format_attempt_progress("Provider Alpha", "gpt-5.5", 1, 1, 91, 90),
             "Provider Alpha | gpt-5.5 | 第 1/1 次尝试 | 已达到 90s 超时，正在终止子进程...",
         )
-
-
-class GuiSmokeTests(unittest.TestCase):
-    @unittest.skipIf(
-        os.environ.get("CI") == "true",
-        "smoke 模式依赖本机真实的 cc-switch 数据库与已安装的 codex 二进制，"
-        "在 CI 全新环境上不具备这些真实数据，故跳过。",
-    )
-    def test_smoke_mode_reports_desktop_dependencies_without_opening_window(self) -> None:
-        completed = subprocess.run(
-            [sys.executable, str(GUI_SCRIPT), "--smoke-test"],
-            cwd=ROOT,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=20,
-        )
-
-        self.assertEqual(completed.returncode, 0, completed.stderr)
-        payload = json.loads(completed.stdout)
-        self.assertEqual(payload["title"], "Codex 供应商探测")
-        self.assertGreaterEqual(payload["provider_count"], 1)
-        self.assertGreaterEqual(payload["model_count"], 3)
-        self.assertTrue(payload["codex_binary_found"])
-        self.assertTrue(payload["settings_path"].endswith("settings.json"))
 
 
 if __name__ == "__main__":

--- a/tests/test_team_policy.py
+++ b/tests/test_team_policy.py
@@ -1,7 +1,9 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+import scripts.team_policy as team_policy
 from scripts.team_policy import (
     PolicyError,
     ChangeRecord,
@@ -16,6 +18,11 @@ from scripts.team_policy import (
     validate_commit_message,
     validate_staged_paths,
     render_release_notes,
+    diff_new_failures,
+    parse_node_failures,
+    parse_unittest_failures,
+    read_baseline_cache,
+    write_baseline_cache,
     _coauthor_names,
     _extract_name,
 )
@@ -238,7 +245,9 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
         self.assertIn("Windows", agents)
         self.assertIn("macOS", agents)
         self.assertIn("auto-merge", agents)
-        self.assertIn("自动发版", agents)
+        self.assertIn("不再自动发版", agents)
+        self.assertIn("人工确认发版", agents)
+        self.assertIn("gh workflow run release.yml", agents)
         self.assertNotIn("只有用户针对具体版本号", agents)
 
     def test_merge_policy_matches_ruleset_gates(self) -> None:
@@ -258,7 +267,8 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
         self.assertIn("gh CLI not required", skill)
         self.assertIn("PR 阶段不运行 CI", agents)
         self.assertIn("release tag", agents)
-        self.assertIn("本地测试未运行或失败", agents)
+        self.assertIn("基线之外的新增失败", agents)
+        self.assertIn("基线相同的既有失败直接放行", agents)
 
     def test_hook_wrappers_are_versioned_and_call_policy(self) -> None:
         for hook_name in ("pre-commit", "commit-msg", "pre-push"):
@@ -311,11 +321,12 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
             {"deletion", "pull_request"},
         )
 
-    def test_auto_release_workflow_is_serialized_and_dispatches_both_platforms(self) -> None:
-        workflow = (ROOT / ".github/workflows/auto-release.yml").read_text(
-            encoding="utf-8"
-        )
-        self.assertIn("push:", workflow)
+    def test_release_workflow_is_manual_dispatch_and_dispatches_both_platforms(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertFalse((ROOT / ".github/workflows/auto-release.yml").exists())
+        self.assertNotIn("branches:", workflow)
         self.assertIn("release-main", workflow)
         self.assertIn("contents: write", workflow)
         self.assertIn("actions: write", workflow)
@@ -330,6 +341,114 @@ class RepositoryGovernanceAssetTests(unittest.TestCase):
             )
             if name == "windows-release.yml":
                 self.assertIn("release-notes", workflow)
+
+
+class VerificationBaselineTests(unittest.TestCase):
+    def test_parses_unittest_failure_ids_including_rerun_timing_suffix(self) -> None:
+        output = (
+            "======================================================================\n"
+            "FAIL: test_alpha (tests.test_proxy_core.UsageTests.test_alpha) [0.001s]\n"
+            "----------------------------------------------------------------------\n"
+            "Traceback (most recent call last):\n"
+            "AssertionError: 1 != 0\n"
+            "\n"
+            "======================================================================\n"
+            "ERROR: test_beta (tests.test_status_config.ConfigTests.test_beta)\n"
+            "----------------------------------------------------------------------\n"
+            "Traceback (most recent call last):\n"
+            "ValueError: boom\n"
+            "\n"
+            "----------------------------------------------------------------------\n"
+            "Ran 2 tests in 0.1s\n"
+            "\n"
+            "FAILED (failures=1, errors=1)\n"
+        )
+
+        self.assertEqual(
+            parse_unittest_failures(output),
+            [
+                "tests.test_proxy_core.UsageTests.test_alpha",
+                "tests.test_status_config.ConfigTests.test_beta",
+            ],
+        )
+
+    def test_parses_unittest_failures_deduplicates_repeated_ids(self) -> None:
+        output = (
+            "ERROR: test_dup (tests.mod.Class.test_dup)\n"
+            "FAIL: test_dup (tests.mod.Class.test_dup)\n"
+        )
+
+        self.assertEqual(parse_unittest_failures(output), ["tests.mod.Class.test_dup"])
+
+    def test_parses_node_tap_failure_names_and_ignores_passing_lines(self) -> None:
+        output = (
+            "TAP version 13\n"
+            "ok 1 - passing case\n"
+            "    not ok 2 - failing case # duration\n"
+            "        not ok 3 - nested failure\n"
+            "1..3\n"
+            "# fail 2\n"
+        )
+
+        self.assertEqual(
+            parse_node_failures(output), ["failing case", "nested failure"]
+        )
+
+    def test_diff_new_failures_passes_baseline_subsets_and_flags_new_entries(self) -> None:
+        baseline = {
+            "python": ["tests.old.EnvTests.test_dns"],
+            "node": {"tests/a.test.js": ["old flaky"]},
+        }
+
+        subset_head = {
+            "python": ["tests.old.EnvTests.test_dns"],
+            "node": {"tests/a.test.js": ["old flaky"]},
+        }
+        self.assertEqual(diff_new_failures(subset_head, baseline), [])
+
+        new_head = {
+            "python": ["tests.old.EnvTests.test_dns", "tests.new.BugTests.test_regression"],
+            "node": {"tests/a.test.js": ["old flaky"], "tests/b.test.js": ["broken case"]},
+        }
+        self.assertEqual(
+            diff_new_failures(new_head, baseline),
+            [
+                "python tests.new.BugTests.test_regression",
+                "node tests/b.test.js :: broken case",
+            ],
+        )
+
+    def test_diff_new_failures_flags_suite_sentinels(self) -> None:
+        baseline = {"python": [], "node": {}}
+
+        self.assertEqual(
+            diff_new_failures({"python": ["<python-suite-exit-nonzero>"], "node": {}}, baseline),
+            ["python <python-suite-exit-nonzero>"],
+        )
+        self.assertEqual(
+            diff_new_failures(
+                {"python": [], "node": {"tests/c.test.js": ["<node-suite-exit-nonzero>"]}},
+                baseline,
+            ),
+            ["node tests/c.test.js :: <node-suite-exit-nonzero>"],
+        )
+
+    def test_baseline_cache_roundtrip_and_stale_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            cache = Path(temp) / "new-base.json"
+            (Path(temp) / "old-base.json").write_text("{}", encoding="utf-8")
+
+            def fake_path(merge_base: str) -> Path:
+                return Path(temp) / f"{merge_base}.json"
+
+            self.assertIsNone(read_baseline_cache("new-base"))
+            with mock.patch.object(team_policy, "_baseline_cache_path", fake_path):
+                write_baseline_cache("new-base", {"python": ["tests.x.Y.test_z"], "node": {}})
+                loaded = read_baseline_cache("new-base")
+
+            self.assertEqual(loaded, {"python": ["tests.x.Y.test_z"], "node": {}})
+            self.assertTrue(cache.exists())
+            self.assertFalse((Path(temp) / "old-base.json").exists())
 
 
 class ReleasePlanningTests(unittest.TestCase):


### PR DESCRIPTION
## 功能说明
docs/changes/2026-09-03-verification-baseline-manual-release.md（status: verified，release_bump: none）

按用户决策调整交付治理，降低时间与 Agent token 成本：

1. **删除 GuiSmokeTests 冒烟测试**：项目后期、改动以小修为主、用户仅三人，真机崩溃影响可控；保留同文件纯单元测试与 `--smoke-test` 脚本入口。
2. **pre-push 全量验证改为基线对比**：`npm ci`/构建/`node --check` 仍为硬门禁；Python 与 node 套件失败集合与 merge-base 基线（缓存于 `.git/policy-baselines/<sha>.json`）比对，子集放行、不排查；新增失败复跑一次确认（防偶发）后拦截。
3. **取消自动发版**：`auto-release.yml` → `release.yml`，改 `workflow_dispatch` 手动触发；Agent 在合并后汇总 verified 说明、给出拟定版本与 notes，**用户同意后**才触发发版；标签仍仅由工作流创建。

同步修改 `AGENTS.md` 与 `git-commit-helper` skill（含硬停止条件改为"出现基线之外的新增失败"）。

## 影响范围
仅交付工具链与治理文档，无产品运行时影响。release tag 时双平台发布工作流的全量测试与阻塞行为不变（发布环境无基线豁免）。

## 风险
- 基线对偶发失败不免疫：新增失败复跑一次确认缓解；基线侧偶发失败导致放行偏松（宁松勿卡）。
- 取消自动发版后改动可能滞留 main 未发布：skill 强制 Agent 合并后必须给出"发版或跳过"提议。

## 验证结果
- `python -m unittest discover -s tests -p "test_*.py"`：554 项全部通过（含新增 `VerificationBaselineTests` 6 项）。
- `node --test tests/*.test.js`、`node --check`、`npm ci` + `npm run build --prefix proxy_static`：全部通过。
- 端到端演练 + 本分支实际推送：新 pre-push 钩子实战输出"全量验证通过：忽略基线既有失败 0 项，无新增失败"（merge-base 基线含 main 上冒烟测试的既有本机失败，HEAD 为空集，正确放行）。