### PR TITLE
🐞 fix(server): 注册 usage-timeline 端点修复正式服务 404

### DIFF
--- a/docs/changes/2026-09-03-usage-timeline-server-route.md
+++ b/docs/changes/2026-09-03-usage-timeline-server-route.md
@@ -1,0 +1,60 @@
++++
+id = "2026-09-03-usage-timeline-server-route"
+type = "fix"
+release_bump = "patch"
+status = "verified"
++++
+
+# 修复用量趋势端点在正式服务下 404
+
+## 目标
+
+让"用量趋势"视图在正式启动的服务（`/control/{codex|claude}/`）下正常返回数据，消除 `GET /control/codex/api/usage-timeline → 404 Not Found`。
+
+## 现状
+
+- v1.8.0（PR #74）在 `local_proxy/core.py` 的 `create_proxy_app` 上新增了 `/control/api/usage-timeline` 端点，前端 `UsageTrendView.vue` 通过 `controlFetch('/api/usage-timeline')` 请求当前服务的 `/control/{app}/api/usage-timeline`。
+- 但正式运行的多服务应用由 `local_proxy/server.py` 的 `_register_control_routes` 按 `/control/{service_id}` 前缀逐条注册控制台路由，该清单漏掉了 usage-timeline，导致线上 404、视图显示 Not Found。
+- 既有端点测试只覆盖 `create_proxy_app`（无前缀单应用变体），没有覆盖 `server.py` 的注册清单，因此漏检。
+
+## 设计范围
+
+1. `local_proxy/server.py`：导入 `TIMELINE_MAX_CUSTOM_SECONDS`，在 `_register_control_routes` 中新增 `control_usage_timeline` 处理器（参数、校验与错误口径与 `core.py` 端点及 usage-history 一致：`usage_window` 默认 `24h`、custom 上限 90 天、可选 `provider_id` 校验 404、`usage_store` 缺失 503、参数错误 422、数据库错误 503、`Cache-Control: no-store`），并注册 `GET {prefix}/api/usage-timeline`。
+2. `tests/test_server.py`：新增 server 级回归测试，直接请求 `/control/codex/api/usage-timeline` 与 `/control/claude/api/usage-timeline`，覆盖 200、双服务数据隔离、跨服务 provider 404。
+
+## 非目标
+
+- 不改 `core.py` 端点行为、`UsageStore.timeline()` 查询逻辑与前端组件。
+- 不重构 `_register_control_routes` 的逐条注册方式。
+
+## 兼容性
+
+- 纯补注册，无行为迁移；`create_proxy_app` 单应用端点保持不变。
+
+## 风险
+
+- server.py 处理器与 core.py 端点行为不一致：通过镜像 usage-history 的实现方式并新增双服务隔离测试控制。
+
+## 测试计划
+
+- `python -m unittest tests.test_server`（新增用例）与 `tests/test_proxy_core`（既有 timeline 用例不回归）。
+- 全量验证：`python -m unittest discover -s tests -p "test_*.py"`、`node --test tests/*.test.js`、`npm ci` + `npm run build --prefix proxy_static`（经基线对比的 pre-push 钩子执行）。
+
+## 实际改动
+
+- `local_proxy/server.py`：
+  - 从 `local_proxy.core` 导入 `TIMELINE_MAX_CUSTOM_SECONDS`；
+  - `_register_control_routes` 新增 `control_usage_timeline` 处理器（`usage_window` 默认 `24h`、custom 上限 90 天、可选 `provider_id` 不存在 404、`usage_store` 缺失 503、参数错误 422、数据库错误 503、`Cache-Control: no-store`，与 `core.py` 端点及 usage-history 口径一致）；
+  - 注册 `GET {prefix}/api/usage-timeline`（紧跟 usage-history 之后）。
+- `tests/test_server.py`：新增 `test_usage_timeline_is_served_per_service_console`——直接请求 `/control/codex/api/usage-timeline` 与 `/control/claude/api/usage-timeline`，断言 200、按小时分桶、桶求和与 total 一致、双服务数据隔离（7/14 tokens）、跨服务 provider 404、`Cache-Control: no-store`。
+
+## 验证结果
+
+- `python -m unittest tests.test_server` → 18 项全部通过（含新增 1 项，2026-09-03 16:30）。
+- `python -m unittest tests.test_proxy_core` → 144 项全部通过（既有 timeline 用例无回归）。
+- `python -m unittest discover -s tests -p "test_*.py"` → 555 项全部通过（2026-09-03 16:31）。
+- `node --test tests/*.test.js`、`node --check`（classic/src/provider_status）、`npm ci` + `npm run build --prefix proxy_static` → 全部通过（2026-09-03 16:31）。
+
+## PR
+
+pending

--- a/docs/changes/2026-09-03-usage-timeline-server-route.md
+++ b/docs/changes/2026-09-03-usage-timeline-server-route.md
@@ -57,4 +57,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/78

--- a/local_proxy/server.py
+++ b/local_proxy/server.py
@@ -28,6 +28,7 @@ from local_proxy.core import (
     RECOVERY_HISTORY_API_LIMIT,
     REQUEST_HISTORY_HOURS,
     REQUEST_HISTORY_WINDOWS,
+    TIMELINE_MAX_CUSTOM_SECONDS,
     USAGE_WINDOWS,
     HealthStatusUrlStore,
     InputItemIdCompatibilityStore,
@@ -507,6 +508,38 @@ def _register_control_routes(
         except (OSError, sqlite3.Error):
             return JSONResponse(status_code=503, content={"detail": "无法读取请求记录"})
         return JSONResponse(content=history, headers={"Cache-Control": "no-store"})
+
+    async def control_usage_timeline(request: Request):
+        provider_id = request.query_params.get("provider_id", "").strip() or None
+        try:
+            window, start_at, end_at = _query_time_range(
+                request,
+                window_param="usage_window",
+                default_window="24h",
+                allowed_windows=USAGE_WINDOWS,
+                max_custom_seconds=TIMELINE_MAX_CUSTOM_SECONDS,
+            )
+        except ValueError as exc:
+            return JSONResponse(status_code=422, content={"detail": str(exc)})
+        if provider_id and not any(
+            provider.provider_id == provider_id for provider in profile.router.providers()
+        ):
+            return JSONResponse(status_code=404, content={"detail": "供应商不存在"})
+        if profile.usage_store is None:
+            return JSONResponse(status_code=503, content={"detail": "Token 记录功能不可用"})
+        try:
+            payload = await asyncio.to_thread(
+                profile.usage_store.timeline,
+                window,
+                start_at=start_at,
+                end_at=end_at,
+                provider_id=provider_id,
+            )
+        except ValueError as exc:
+            return JSONResponse(status_code=422, content={"detail": str(exc)})
+        except (OSError, sqlite3.Error):
+            return JSONResponse(status_code=503, content={"detail": "无法读取用量趋势"})
+        return JSONResponse(content=payload, headers={"Cache-Control": "no-store"})
 
     async def control_requests(request: Request):
         if profile.usage_store is None:
@@ -1168,6 +1201,7 @@ def _register_control_routes(
     app.add_api_route(f"{prefix}/api/status", control_status, methods=["GET"], include_in_schema=False)
     app.add_api_route(f"{prefix}/api/recovery-history", control_recovery_history, methods=["GET"], include_in_schema=False)
     app.add_api_route(f"{prefix}/api/usage-history", control_usage_history, methods=["GET"], include_in_schema=False)
+    app.add_api_route(f"{prefix}/api/usage-timeline", control_usage_timeline, methods=["GET"], include_in_schema=False)
     app.add_api_route(f"{prefix}/api/requests", control_requests, methods=["GET"], include_in_schema=False)
     app.add_api_route(f"{prefix}/api/sessions", control_sessions, methods=["GET"], include_in_schema=False)
     app.add_api_route(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -357,6 +357,54 @@ class UnifiedProxyAppTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(claude_history.json()["items"][0]["model"], "claude-test")
         self.assertEqual(crossed.status_code, 404)
 
+    async def test_usage_timeline_is_served_per_service_console(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.codex_profile.usage_store = UsageStore(root / "codex.sqlite3")
+            self.claude_profile.usage_store = UsageStore(root / "claude.sqlite3")
+            self.codex_profile.usage_store.record(
+                provider_id="codex-a",
+                model="gpt-test",
+                usage=TokenUsage(5, 2, 7),
+                status_code=200,
+            )
+            self.claude_profile.usage_store.record(
+                provider_id="claude-a",
+                model="claude-test",
+                usage=TokenUsage(11, 3, 14),
+                status_code=200,
+            )
+
+            codex_timeline = await self.client.get(
+                "/control/codex/api/usage-timeline",
+                params={"usage_window": "24h"},
+            )
+            claude_timeline = await self.client.get(
+                "/control/claude/api/usage-timeline",
+                params={"usage_window": "24h"},
+            )
+            crossed = await self.client.get(
+                "/control/codex/api/usage-timeline",
+                params={"usage_window": "24h", "provider_id": "claude-a"},
+            )
+            no_store = await self.client.get(
+                "/control/codex/api/usage-timeline",
+                params={"usage_window": "24h", "provider_id": "codex-a"},
+            )
+
+        self.assertEqual(codex_timeline.status_code, 200)
+        self.assertEqual(codex_timeline.json()["granularity"], "hour")
+        self.assertEqual(codex_timeline.json()["total"]["total_tokens"], 7)
+        self.assertEqual(
+            sum(bucket["total_tokens"] for bucket in codex_timeline.json()["buckets"]),
+            7,
+        )
+        self.assertEqual(claude_timeline.status_code, 200)
+        self.assertEqual(claude_timeline.json()["total"]["total_tokens"], 14)
+        self.assertEqual(crossed.status_code, 404)
+        self.assertEqual(no_store.status_code, 200)
+        self.assertEqual(no_store.headers["cache-control"], "no-store")
+
     async def test_both_control_views_update_the_same_runtime_settings(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## 功能说明
docs/changes/2026-09-03-usage-timeline-server-route.md（status: verified，release_bump: patch）

## 问题
v1.8.0 的用量趋势视图在正式服务下点击显示 Not Found：前端请求 `/control/codex/api/usage-timeline` 返回 404。根因是端点只在 `core.py` 的单应用变体（`create_proxy_app`）注册，漏了 `server.py` `_register_control_routes` 的多服务前缀注册清单；既有测试只覆盖前者，未拦截。

## 修复
- `server.py` 新增 `control_usage_timeline` 处理器并注册 `GET {prefix}/api/usage-timeline`（参数与错误口径与 core.py 端点及 usage-history 一致）。
- `tests/test_server.py` 新增 server 级回归测试：双服务控制台 200/按小时分桶/桶求和与 total 一致/数据隔离（7/14 tokens）/跨服务 provider 404/no-store。

## 验证结果
- `python -m unittest discover -s tests -p "test_*.py"`：555 项全部通过（新增 1 项）。
- `node --test tests/*.test.js`、`node --check`、`npm ci` + `npm run build --prefix proxy_static`：全部通过。
- 推送时经新版 pre-push 基线对比钩子验证通过。