### PR TITLE
📃 docs(share): 补记深色底板修复的 PR 地址

### DIFF
--- a/docs/changes/2026-09-04-share-card-dark-backdrop.md
+++ b/docs/changes/2026-09-04-share-card-dark-backdrop.md
@@ -58,4 +58,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/85


### PR DESCRIPTION
前次文档提交（84574d4）因网络故障未随 PR #85 合并，主线记录仍为 pending。本 PR 仅补记 #85 的最终地址到 docs/changes/2026-09-04-share-card-dark-backdrop.md 的 PR 字段，无代码变化。