### PR TITLE
✨ feat(release): Release 信息改为通俗简短的用户摘要

### DIFF
--- a/docs/changes/2026-09-04-plain-release-notes.md
+++ b/docs/changes/2026-09-04-plain-release-notes.md
@@ -64,4 +64,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/88

--- a/docs/changes/2026-09-04-plain-release-notes.md
+++ b/docs/changes/2026-09-04-plain-release-notes.md
@@ -1,0 +1,67 @@
++++
+id = "2026-09-04-plain-release-notes"
+type = "chore"
+release_bump = "patch"
+headline = "版本更新说明改为一眼看懂的简短摘要：按新功能、问题修复分组，每条一句话"
+status = "verified"
++++
+
+# Release 信息改为通俗简短的用户摘要
+
+## 目标
+
+把 GitHub Release 正文从"变更说明全文堆叠"改为面向用户的通俗摘要：按 新功能/问题修复/其他改进 分组，每条一行（功能名 + 一句话说明），文末附变更说明链接。优化不增加任何门禁或发版耗时。
+
+## 现状
+
+- `render_release_notes()`（`scripts/team_policy.py`）把每条 verified 说明的目标、实际改动、兼容性、风险、验证结果、PR 六个章节全文倒进 release 正文；其中"实际改动/验证结果"是长篇技术审计（含命令、SHA、文件清单），用户看不懂也不想看。
+- 发版工作流（`windows-release.yml`）经 `release-notes` CLI 生成 `.build/release-notes.md` 后作为 release body 发布。
+
+## 设计范围
+
+1. 重写 `render_release_notes()`：
+   - 标题 `# Codex 本地中转 {tag}` + 一句导语（本次更新 N 项改进）；
+   - 按 metadata.type 分组：feature → ✨ 新功能、fix → 🐞 问题修复、其余 → 🛠️ 其他改进；
+   - 每条一行：`- **{功能名}**：{一句话}`；功能名取说明 H1（新增解析，缺省用 id）；一句话优先取可选 front-matter `headline` 字段，否则从"目标"章节自动提取首句（去列表符号，截断至约 60 字符）；
+   - 文末"技术细节"区附每条说明的 GitHub 链接（blob/{tag}/docs/changes/...）。
+2. `parse_change_record` 增补 H1 标题解析（`title` 字段，缺省回退 id）；`headline` 为可选 front-matter，**不加入必填校验**——旧记录与新记录零成本兼容，门禁不变。
+3. 不改 `release.yml`、平台发版工作流、AGENTS.md 门禁与 skill 步骤——生成入口仍是同一条 `release-notes` CLI，耗时不变。
+
+## 非目标
+
+- 不改变更说明本身的写法与门禁要求（那是开发审计资产）；
+- 不改标签/发布流程与确认机制；
+- 不做多语言。
+
+## 兼容性
+
+- 纯渲染层重写；`release-notes` CLI 签名不变；`headline` 可选字段向后兼容。release 页面格式是用户可见变化，故 release_bump=patch。
+
+## 风险
+
+1. 自动摘要质量取决于"目标"首句：以历史真实发布范围（v1.8.0→v1.9.0→v1.10.0→v1.10.1）逐条迭代校验可读性；不理想的记录未来可加一行 headline 覆盖。
+2. H1 缺失回退 id，不影响渲染健壮性。
+
+## 测试计划
+
+- `tests/test_team_policy.py`：重写 release notes 断言（分组、一句话、headline 覆盖、首句截断、链接、不再包含验证结果/实际改动手）；`parse_change_record` H1 解析用例。
+- 本地以历史 tag 区间真实数据渲染 review。
+- 全量验证后 PR 合并，真实发版 v1.10.2 验证线上 release 页面效果。
+
+## 实际改动
+
+- `scripts/team_policy.py`：
+  - `ChangeRecord` 新增可选 `title` 字段；`parse_change_record` 解析正文 H1 作为功能名（缺省回退 id）；
+  - `render_release_notes()` 重写：标题 + 一句导语（N 项改进），按 type 分组（✨ 新功能 / 🐞 问题修复 / 🛠️ 其他改进），每条 `- **功能名**：一句话`；摘要优先取可选 front-matter `headline`，否则自动提取"目标"首句（剥 markdown 记号/链接/本机路径、清理空括号、按全角标点断句、60 字截断且不在未闭合括号内截断、标题 30 字截断）；文末"技术细节"区附每条说明的 GitHub blob 链接；
+  - `headline` 未加入必填校验（完全可选，旧记录零成本兼容）。
+- `tests/test_team_policy.py`：H1 解析断言；release notes 测试重写为通俗格式断言（分组、headline 覆盖优先、无技术章节泄漏、链接计数、长标题/括号截断）。
+- 工作流与门禁零改动：`release.yml`/`windows-release.yml` 仍走同一条 `release-notes` CLI。
+
+## 验证结果
+
+- 历史真实区间渲染迭代（2026-09-04 01:40–01:42）：v1.8.1→v1.9.0 与 v1.10.0→main 两个区间逐条 review——条目均为单行通俗摘要，无路径/markdown 记号/未闭合括号截断。
+- `python -m unittest tests.test_team_policy` → 33 项通过；全量 `python -m unittest discover -s tests -p "test_*.py"` → 560 项全部通过；`node --test tests/*.test.js` 全部通过（2026-09-04 01:43）。
+
+## PR
+
+pending

--- a/scripts/team_policy.py
+++ b/scripts/team_policy.py
@@ -76,6 +76,7 @@ class ChangeRecord:
     path: Path
     metadata: dict[str, str]
     sections: dict[str, str]
+    title: str = ""
 
 
 def parse_change_record(path: Path) -> ChangeRecord:
@@ -97,7 +98,13 @@ def parse_change_record(path: Path) -> ChangeRecord:
         value_start = match.end()
         value_end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
         sections[match.group(1).strip()] = body[value_start:value_end].strip()
-    return ChangeRecord(path=path, metadata=metadata, sections=sections)
+    title_match = re.search(r"(?m)^#\s+(?!\#)([^\r\n]+?)\s*$", body)
+    return ChangeRecord(
+        path=path,
+        metadata=metadata,
+        sections=sections,
+        title=title_match.group(1).strip() if title_match else "",
+    )
 
 
 def validate_change_record(record: ChangeRecord, *, required_status: str) -> None:
@@ -165,24 +172,75 @@ def build_release_plan(base_tag: str, records: list[ChangeRecord]) -> dict[str, 
     }
 
 
+RELEASE_REPO_URL = "https://github.com/AI-Routing-Research-Institute/codex-provider-hub"
+RELEASE_NOTE_GROUPS = (
+    ("✨ 新功能", ("feature",)),
+    ("🐞 问题修复", ("fix",)),
+    ("🛠️ 其他改进", ("chore", "docs", "refactor", "style", "performance", "build", "test")),
+)
+
+
+def _plain_sentence(text: str, limit: int = 60) -> str:
+    """Collapse a section into one short plain sentence for release notes."""
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    collapsed = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1", collapsed)
+    collapsed = collapsed.replace("**", "").replace("`", "")
+    collapsed = re.sub(r"[A-Za-z]:\\[^\s，。）)（]*", "", collapsed)
+    collapsed = re.sub(r"(?:~|／|/)[^\s，。）)（]*\.(?:md|html|py|js|vue|yml)", "", collapsed)
+    collapsed = re.sub(r"（[，、\s]*）", "", collapsed)
+    collapsed = collapsed.replace("（，", "（").replace("（ ", "（")
+    collapsed = re.sub(r"^[-*•\d.\s]+", "", collapsed)
+    cut = len(collapsed)
+    for separator in ("。", "；", "：", "！", "？"):
+        index = collapsed.find(separator)
+        if index != -1:
+            cut = min(cut, index)
+    sentence = collapsed[:cut].strip(" ，,")
+    if len(sentence) > limit:
+        trimmed = sentence[:limit]
+        depth = trimmed.count("（") + trimmed.count("(") - trimmed.count("）") - trimmed.count(")")
+        if depth > 0:
+            bracket = max(trimmed.rfind("（", 0, limit), trimmed.rfind("(", 0, limit))
+            if bracket > 20:
+                trimmed = trimmed[:bracket]
+        sentence = trimmed.rstrip(" ，,（(") + "…"
+    return sentence
+
+
+def _record_headline(record: ChangeRecord) -> str:
+    headline = record.metadata.get("headline", "").strip()
+    if headline:
+        return _plain_sentence(headline, limit=80)
+    return _plain_sentence(record.sections.get("目标", ""))
+
+
+def _record_title(record: ChangeRecord) -> str:
+    title = record.title or record.metadata.get("id", "")
+    if len(title) > 30:
+        title = title[:30].rstrip() + "…"
+    return title
+
+
 def render_release_notes(tag: str, records: list[ChangeRecord]) -> str:
-    lines = [f"# Codex Provider Hub {tag}", "", "本版本由已验证的功能变更说明自动生成。", ""]
+    lines = [
+        f"# Codex 本地中转 {tag}",
+        "",
+        f"本次更新 {len(records)} 项改进。",
+        "",
+    ]
+    for group_title, type_names in RELEASE_NOTE_GROUPS:
+        grouped = [record for record in records if record.metadata.get("type") in type_names]
+        if not grouped:
+            continue
+        lines.append(f"## {group_title}")
+        for record in grouped:
+            lines.append(f"- **{_record_title(record)}**：{_record_headline(record)}")
+        lines.append("")
+    lines.extend(["## 技术细节", ""])
     for record in records:
-        metadata = record.metadata
-        lines.extend(
-            [
-                f"## {metadata['id']}",
-                f"- 类型：{metadata['type']}",
-                f"- 发布级别：{metadata['release_bump']}",
-                f"- 目标：{record.sections['目标']}",
-                f"- 实际改动：{record.sections['实际改动']}",
-                f"- 兼容性：{record.sections['兼容性']}",
-                f"- 风险：{record.sections['风险']}",
-                f"- 验证结果：{record.sections['验证结果']}",
-                f"- PR：{record.sections['PR']}",
-                "",
-            ]
-        )
+        title = _record_title(record)
+        path = str(record.path).replace("\\", "/")
+        lines.append(f"- [{title}]({RELEASE_REPO_URL}/blob/{tag}/{path})")
     return "\n".join(lines)
 
 

--- a/tests/test_team_policy.py
+++ b/tests/test_team_policy.py
@@ -93,6 +93,7 @@ class ChangeRecordTests(unittest.TestCase):
         record = parse_change_record(self.write_record())
 
         self.assertEqual(record.metadata["release_bump"], "minor")
+        self.assertEqual(record.title, "Agent delivery")
         self.assertEqual(record.sections["目标"], "建立 Agent 自驱交付流水线。")
         validate_change_record(record, required_status="planned")
 
@@ -452,12 +453,16 @@ class VerificationBaselineTests(unittest.TestCase):
 
 
 class ReleasePlanningTests(unittest.TestCase):
-    def make_record(self, bump: str, title: str) -> ChangeRecord:
+    def make_record(self, bump: str, title: str, *, type: str = "feature", headline: str | None = None, goal: str | None = None) -> ChangeRecord:
+        metadata = {"id": title, "type": type, "release_bump": bump, "status": "verified"}
+        if headline is not None:
+            metadata["headline"] = headline
         return ChangeRecord(
             path=Path(f"docs/changes/{title}.md"),
-            metadata={"id": title, "type": "feature", "release_bump": bump, "status": "verified"},
+            metadata=metadata,
+            title=title,
             sections={
-                "目标": title,
+                "目标": goal if goal is not None else title,
                 "现状": "old",
                 "设计范围": "scope",
                 "非目标": "none",
@@ -478,14 +483,60 @@ class ReleasePlanningTests(unittest.TestCase):
         self.assertTrue(plan["release"])
         self.assertEqual(plan["tag"], "v0.2.0")
 
-    def test_none_records_do_not_release_and_notes_include_verified_changes(self) -> None:
+    def test_none_records_do_not_release_and_notes_stay_plain(self) -> None:
         record = self.make_record("none", "docs-only")
         plan = build_release_plan("v0.1.7", [record])
 
         self.assertFalse(plan["release"])
-        notes = render_release_notes("v0.1.8", [record])
+        notes = render_release_notes("v1.8.0", [record])
         self.assertIn("docs-only", notes)
-        self.assertIn("验证结果", notes)
+        self.assertIn("## 技术细节", notes)
+        self.assertIn("/blob/v1.8.0/docs/changes/", notes)
+        self.assertNotIn("验证结果", notes)
+        self.assertNotIn("实际改动", notes)
+
+    def test_release_notes_group_by_type_and_prefer_headline(self) -> None:
+        feature = self.make_record(
+            "minor",
+            "feature-x",
+            goal="在新版控制台新增“用量趋势”视图：以时间曲线展示 token 消耗（输入/输出/合计）随时间的变化，按小时或按天分桶",
+        )
+        fix = self.make_record(
+            "patch",
+            "fix-y",
+            type="fix",
+            headline="分享到微信不再出现白色边角",
+            goal="导出画布整幅填充 #0b0d10 深色底板（四周 12px），`context.translate(margin, margin)` 于卡片原点做既有圆角裁剪",
+        )
+        chore = self.make_record("patch", "chore-z", type="chore", goal="同步门禁描述。")
+
+        notes = render_release_notes("v1.10.2", [feature, fix, chore])
+
+        self.assertTrue(notes.startswith("# Codex 本地中转 v1.10.2"))
+        self.assertIn("本次更新 3 项改进。", notes)
+        self.assertIn("## ✨ 新功能", notes)
+        self.assertIn("## 🐞 问题修复", notes)
+        self.assertIn("## 🛠️ 其他改进", notes)
+        self.assertIn("**feature-x**：在新版控制台新增“用量趋势”视图", notes)
+        self.assertNotIn("以时间曲线展示", notes)
+        self.assertIn("**fix-y**：分享到微信不再出现白色边角", notes)
+        self.assertNotIn("translate", notes)
+        self.assertNotIn("`", notes)
+        self.assertIn("**chore-z**：同步门禁描述", notes)
+        self.assertEqual(notes.count("/blob/v1.10.2/docs/changes/"), 3)
+
+    def test_release_notes_truncate_long_titles_and_brackets(self) -> None:
+        long_record = self.make_record(
+            "minor",
+            "a-very-long-title" * 3,
+            goal="把图表升级为多种可切换的图型，视觉规范参考开源 Skill Lieflat Charts（手写 SVG 复刻，不复制其代码）",
+        )
+
+        notes = render_release_notes("v1.10.2", [long_record])
+
+        self.assertIn("…**：", notes)
+        bracketed = [line for line in notes.splitlines() if line.startswith("- **")][0]
+        self.assertFalse(bracketed.rstrip("…").endswith("（"), bracketed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 功能说明
docs/changes/2026-09-04-plain-release-notes.md（status: verified，release_bump: patch）

用户反馈 release 信息太复杂太专业。根因：render_release_notes 把每条变更说明的六个章节（目标/实际改动/兼容性/风险/验证结果/PR）全文堆进正文。

重写为用户视角摘要：**按 新功能/问题修复/其他改进 分组，每条一行（功能名 + 一句话）**，文末附变更说明链接。摘要优先取可选 `headline` 字段（不加门禁、旧记录零成本），否则从"目标"章节自动提取首句（剥路径/markdown、全角标点断句、60 字截断、不在未闭合括号截断）。

**门禁与发版零增负**：工作流、CLI 签名、耗时均不变。

## 验证结果
- 历史真实区间（v1.8.1→v1.9.0、v1.10.0→main）渲染逐条 review 通过
- `python -m unittest discover`：560 项全部通过（含重写的 release notes 断言）；`node --test` 全部通过
- 合并后将真实发版验证线上 release 页面