### PR TITLE
🐞 fix(release): headline 摘要不再被冒号截断

### DIFF
--- a/docs/changes/2026-09-04-release-notes-headline-keep.md
+++ b/docs/changes/2026-09-04-release-notes-headline-keep.md
@@ -1,0 +1,51 @@
++++
+id = "2026-09-04-release-notes-headline-keep"
+type = "fix"
+release_bump = "none"
+headline = "修正更新摘要里人工一句话被冒号截断的问题，现在完整保留"
+status = "verified"
++++
+
+# Release 摘要 headline 不再被冒号截断
+
+## 目标
+
+`headline` 是人工撰写的通俗一句话，应整段进入 release 摘要；此前被按全角冒号断句，冒号后的内容被丢弃。
+
+## 现状
+
+`_record_headline()` 对 headline 复用了"目标"章节的首句提取逻辑（含冒号断句），例如 headline "版本更新说明改为一眼看懂的简短摘要：按新功能、问题修复分组，每条一句话" 只保留了冒号前半句。
+
+## 设计范围
+
+- `_plain_sentence()` 新增 `cut_at_separators` 开关；headline 路径设为 False（仅清洗与限长，不断句），自动提取"目标"的路径行为不变。
+
+## 非目标
+
+- 不改其他渲染逻辑与门禁。
+
+## 兼容性
+
+- 纯渲染层；无新增字段与流程变化。
+
+## 风险
+
+- 无。
+
+## 测试计划
+
+- `tests/test_team_policy.py`：headline 含冒号时完整保留的断言。
+
+## 实际改动
+
+- `scripts/team_policy.py`：`_plain_sentence(text, limit, *, cut_at_separators=True)`；`_record_headline` 的 headline 分支传 `cut_at_separators=False`。
+- `tests/test_team_policy.py`：`test_release_notes_group_by_type_and_prefer_headline` 的 fix 记录 headline 改为含冒号完整句并断言整句出现在 notes。
+
+## 验证结果
+
+- `python -m unittest tests.test_team_policy` → 33 项通过（2026-09-04 01:51）。
+- 本地渲染 `release-notes --base-tag v1.10.1 --head <分支>`：headline 完整保留"版本更新说明改为一眼看懂的简短摘要：按新功能、问题修复分组，每条一句话"。
+
+## PR
+
+pending

--- a/docs/changes/2026-09-04-release-notes-headline-keep.md
+++ b/docs/changes/2026-09-04-release-notes-headline-keep.md
@@ -48,4 +48,4 @@ status = "verified"
 
 ## PR
 
-pending
+https://github.com/AI-Routing-Research-Institute/codex-provider-hub/pull/89

--- a/scripts/team_policy.py
+++ b/scripts/team_policy.py
@@ -180,7 +180,7 @@ RELEASE_NOTE_GROUPS = (
 )
 
 
-def _plain_sentence(text: str, limit: int = 60) -> str:
+def _plain_sentence(text: str, limit: int = 60, *, cut_at_separators: bool = True) -> str:
     """Collapse a section into one short plain sentence for release notes."""
     collapsed = re.sub(r"\s+", " ", text).strip()
     collapsed = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1", collapsed)
@@ -191,10 +191,11 @@ def _plain_sentence(text: str, limit: int = 60) -> str:
     collapsed = collapsed.replace("（，", "（").replace("（ ", "（")
     collapsed = re.sub(r"^[-*•\d.\s]+", "", collapsed)
     cut = len(collapsed)
-    for separator in ("。", "；", "：", "！", "？"):
-        index = collapsed.find(separator)
-        if index != -1:
-            cut = min(cut, index)
+    if cut_at_separators:
+        for separator in ("。", "；", "：", "！", "？"):
+            index = collapsed.find(separator)
+            if index != -1:
+                cut = min(cut, index)
     sentence = collapsed[:cut].strip(" ，,")
     if len(sentence) > limit:
         trimmed = sentence[:limit]
@@ -210,7 +211,7 @@ def _plain_sentence(text: str, limit: int = 60) -> str:
 def _record_headline(record: ChangeRecord) -> str:
     headline = record.metadata.get("headline", "").strip()
     if headline:
-        return _plain_sentence(headline, limit=80)
+        return _plain_sentence(headline, limit=80, cut_at_separators=False)
     return _plain_sentence(record.sections.get("目标", ""))
 
 

--- a/tests/test_team_policy.py
+++ b/tests/test_team_policy.py
@@ -505,7 +505,7 @@ class ReleasePlanningTests(unittest.TestCase):
             "patch",
             "fix-y",
             type="fix",
-            headline="分享到微信不再出现白色边角",
+            headline="分享卡片：粘贴到微信不再出现白色边角",
             goal="导出画布整幅填充 #0b0d10 深色底板（四周 12px），`context.translate(margin, margin)` 于卡片原点做既有圆角裁剪",
         )
         chore = self.make_record("patch", "chore-z", type="chore", goal="同步门禁描述。")
@@ -519,7 +519,7 @@ class ReleasePlanningTests(unittest.TestCase):
         self.assertIn("## 🛠️ 其他改进", notes)
         self.assertIn("**feature-x**：在新版控制台新增“用量趋势”视图", notes)
         self.assertNotIn("以时间曲线展示", notes)
-        self.assertIn("**fix-y**：分享到微信不再出现白色边角", notes)
+        self.assertIn("**fix-y**：分享卡片：粘贴到微信不再出现白色边角", notes)
         self.assertNotIn("translate", notes)
         self.assertNotIn("`", notes)
         self.assertIn("**chore-z**：同步门禁描述", notes)


### PR DESCRIPTION
## 功能说明
docs/changes/2026-09-04-release-notes-headline-keep.md（status: verified，release_bump: none）

#88 的追加修正：`headline` 是人工撰写的通俗一句话，应整段进入 release 摘要；此前复用了"目标"章节的冒号断句逻辑导致冒号后内容被丢弃。`_plain_sentence` 新增 `cut_at_separators` 开关，headline 路径仅清洗限长不断句。门禁与流程零变化。

## 验证结果
- `python -m unittest discover -s tests -p "test_*.py"`：560 项全部通过（含含冒号 headline 完整保留断言）
- 分支本地渲染 `release-notes` 验证 headline 整句输出；`node --test` 全部通过